### PR TITLE
chore: satisfy remaining Ruff format check

### DIFF
--- a/immich_doctor/services/dashboard_health.py
+++ b/immich_doctor/services/dashboard_health.py
@@ -231,8 +231,7 @@ class DashboardHealthService:
                 status=DashboardHealthStatus.UNKNOWN,
                 summary="Consistency readiness is not available in this process.",
                 details=(
-                    "Open the Consistency page for the current "
-                    "catalog-backed validation state."
+                    "Open the Consistency page for the current catalog-backed validation state."
                 ),
                 updatedAt=timestamp,
                 blocking=False,

--- a/immich_doctor/services/database_overview.py
+++ b/immich_doctor/services/database_overview.py
@@ -345,8 +345,7 @@ class DatabaseOverviewService:
                 "status": self._catalog_job_status(job).value,
                 "summary": str(job.get("summary") or "Consistency findings are available."),
                 "details": (
-                    "Open the Consistency page for detailed compare rows "
-                    "and repair workflows."
+                    "Open the Consistency page for detailed compare rows and repair workflows."
                 ),
                 "route": "/consistency",
             }

--- a/tests/unit/test_dashboard_health_service.py
+++ b/tests/unit/test_dashboard_health_service.py
@@ -150,8 +150,7 @@ def test_dashboard_health_service_reports_consistency_waiting_on_scan() -> None:
                 "jobType": "catalog_consistency_validation",
                 "state": "pending",
                 "summary": (
-                    "Catalog consistency validation is waiting for the "
-                    "catalog scan to finish."
+                    "Catalog consistency validation is waiting for the catalog scan to finish."
                 ),
                 "result": {
                     "blockedBy": {

--- a/tests/unit/test_database_overview_service.py
+++ b/tests/unit/test_database_overview_service.py
@@ -144,8 +144,7 @@ def test_database_overview_service_marks_related_findings_as_waiting_during_inde
             {
                 "state": "pending",
                 "summary": (
-                    "Catalog consistency validation is waiting for the "
-                    "catalog scan to finish."
+                    "Catalog consistency validation is waiting for the catalog scan to finish."
                 ),
                 "result": {
                     "blockedBy": {


### PR DESCRIPTION
## Summary
- apply the remaining Ruff formatter output for the database/readiness changes
- restore a green required Ruff check on GitHub
- keep behavior unchanged