### PR TITLE
Promote stable catalog remediation subset to main

### DIFF
--- a/docs/ui-contract.md
+++ b/docs/ui-contract.md
@@ -129,7 +129,7 @@ for cached storage-vs-DB mismatch classes.
 
 Canonical behavior:
 
-- render broken DB originals and `.fuse_hidden*` storage orphans as separate sections
+- render broken DB originals, zero-byte files, and `.fuse_hidden*` storage orphans as separate sections
 - keep checkbox selection explicit per section
 - support single-item, selected-items, and all-eligible preview flows
 - keep preview separate from apply
@@ -138,10 +138,20 @@ Canonical behavior:
 
 Broken DB original rules:
 
-- show `missing_confirmed`, `found_elsewhere`, and `unresolved_search_error` as distinct badges
+- show `missing_confirmed`, `found_elsewhere`, `found_with_hash_match`, and `unresolved_search_error` as distinct badges
 - show expected DB path and found path for `found_elsewhere`
 - explain that `found_elsewhere` is not auto-deleted because the file may still exist elsewhere
+- show checksum-verification state for path-mismatch candidates when available
 - expose destructive cleanup only for `missing_confirmed`
+- expose explicit DB path-fix only for `found_with_hash_match`
+
+Zero-byte rules:
+
+- `.immich` must not be rendered as a remediation candidate
+- show `zero_byte_upload_orphan`, `zero_byte_upload_critical`, `zero_byte_video_derivative`, and `zero_byte_thumb_derivative` as distinct badges
+- explain that `zero_byte_upload_critical` is still referenced as an original and therefore not deletable by default
+- expose explicit delete apply only for orphan or derivative classes
+- make clear that derivative deletion is a cleanup step, not an implicit regenerate step
 
 `.fuse_hidden*` orphan rules:
 

--- a/docs/ui-contract.md
+++ b/docs/ui-contract.md
@@ -122,6 +122,35 @@ Recovery limits shown in UI:
 - unsupported schema mappings remain blocked and must be reported clearly
 - already removed rows should be shown as such instead of being hidden
 
+## Catalog-backed remediation UI
+
+The catalog-backed consistency page now also exposes explicit remediation review
+for cached storage-vs-DB mismatch classes.
+
+Canonical behavior:
+
+- render broken DB originals and `.fuse_hidden*` storage orphans as separate sections
+- keep checkbox selection explicit per section
+- support single-item, selected-items, and all-eligible preview flows
+- keep preview separate from apply
+- only enable apply after preview plus explicit confirmation checkboxes
+- keep item typing explicit in the UI state and API payloads
+
+Broken DB original rules:
+
+- show `missing_confirmed`, `found_elsewhere`, and `unresolved_search_error` as distinct badges
+- show expected DB path and found path for `found_elsewhere`
+- explain that `found_elsewhere` is not auto-deleted because the file may still exist elsewhere
+- expose destructive cleanup only for `missing_confirmed`
+
+`.fuse_hidden*` orphan rules:
+
+- `.immich` must not be rendered as a repair candidate
+- show `blocked_in_use`, `deletable_orphan`, and `check_failed` as distinct badges
+- explain that `blocked_in_use` cannot be removed safely yet
+- expose delete apply only for `deletable_orphan`
+- if the in-use check is unavailable, surface the backend reason instead of faking readiness
+
 ## Backup contract
 
 The backup UI must treat backend state as the source of truth for:

--- a/docs/ui-contract.md
+++ b/docs/ui-contract.md
@@ -127,6 +127,17 @@ Recovery limits shown in UI:
 The catalog-backed consistency page now also exposes explicit remediation review
 for cached storage-vs-DB mismatch classes.
 
+Catalog-backed validation filtering rules:
+
+- report only actionable inconsistencies from the cached DB-vs-storage compare
+- suppress valid DB/storage matches entirely
+- suppress valid Motion/Live-Photo video components when:
+  - the asset row is a `VIDEO`
+  - the stored `originalPath` resolves into `encoded-video`
+  - a sibling image references that asset through `livePhotoVideoId`
+- if such a motion component is logically valid but the underlying storage file is missing, keep reporting it as a real missing-file inconsistency instead of suppressing it
+- keep unexpected `encoded-video` roots visible when the motion linkage is absent or cannot be verified
+
 Canonical behavior:
 
 - render broken DB originals, zero-byte files, and `.fuse_hidden*` storage orphans as separate sections

--- a/docs/workflows/repair.md
+++ b/docs/workflows/repair.md
@@ -83,6 +83,45 @@ Recovery limits:
 - if a record is already absent from the current scan scope, it is reported as `already_removed`
 - if the schema contains unsupported asset references, the run stays blocked until the mapping is modeled safely
 
+## Catalog-backed remediation findings
+
+The catalog-backed consistency page now exposes two additional review-first
+flows based on the latest committed storage snapshot.
+
+Broken DB originals:
+
+- scope: DB asset rows whose mapped `originalPath` is absent from the cached uploads snapshot
+- classifications stay explicit:
+  - `missing_confirmed`
+  - `found_elsewhere`
+  - `unresolved_search_error`
+- relocation search is read-only and uses the cached storage inventory
+- `found_elsewhere` stays inspect-only by default:
+  - no auto-delete
+  - no auto-rebind
+  - expected path and found path must stay visible to the operator
+- only `missing_confirmed` is eligible for explicit DB cleanup preview/apply
+- DB cleanup apply reuses the existing repair-run, journal, and restore-metadata foundation
+
+`.fuse_hidden*` storage orphans:
+
+- scope: storage-only uploads files whose name starts with `.fuse_hidden`
+- `.immich` is ignored explicitly and must never appear as a repair candidate
+- classifications stay explicit:
+  - `blocked_in_use`
+  - `deletable_orphan`
+  - `check_failed`
+- in-use checks depend on runtime tooling and must report the real reason when unavailable
+- only `deletable_orphan` is eligible for explicit delete preview/apply
+- blocked or failed-check rows stay informational and do not expose destructive apply
+
+Shared remediation rules:
+
+- preview and apply remain separate
+- selection may target a single row, selected rows, or all eligible rows in one class
+- DB cleanup and `.fuse_hidden*` deletion stay separate flows and must not be mixed in one ambiguous handler
+- scan time remains non-destructive
+
 CLI and UI:
 
 - CLI keeps explicit dry-run/apply semantics and does not use the UI checkbox gate

--- a/docs/workflows/repair.md
+++ b/docs/workflows/repair.md
@@ -94,14 +94,31 @@ Broken DB originals:
 - classifications stay explicit:
   - `missing_confirmed`
   - `found_elsewhere`
+  - `found_with_hash_match`
   - `unresolved_search_error`
 - relocation search is read-only and uses the cached storage inventory
+- path-mismatch rows such as `/upload/upload/...` versus the configured uploads root may surface through the same review flow
 - `found_elsewhere` stays inspect-only by default:
   - no auto-delete
-  - no auto-rebind
+  - no auto-rebind without checksum-backed verification
   - expected path and found path must stay visible to the operator
 - only `missing_confirmed` is eligible for explicit DB cleanup preview/apply
+- only `found_with_hash_match` is eligible for explicit DB path-fix preview/apply
 - DB cleanup apply reuses the existing repair-run, journal, and restore-metadata foundation
+- DB path-fix apply updates `public.asset.originalPath` only and records old/new values in the repair journal with DB-value undo metadata
+
+Zero-byte files:
+
+- scope: cached zero-byte rows from `uploads`, `thumbs`, and `video`
+- classifications stay explicit:
+  - `zero_byte_upload_orphan`
+  - `zero_byte_upload_critical`
+  - `zero_byte_video_derivative`
+  - `zero_byte_thumb_derivative`
+- `.immich` stays ignored explicitly and must never appear as a repair candidate
+- `zero_byte_upload_critical` stays inspect-only because the DB still references the original upload
+- `zero_byte_upload_orphan`, `zero_byte_video_derivative`, and `zero_byte_thumb_derivative` are eligible for explicit delete preview/apply
+- deleting a zero-byte derivative is not an automatic regenerate step; it only removes the broken artifact so later operator-led regeneration stays possible
 
 `.fuse_hidden*` storage orphans:
 
@@ -119,7 +136,7 @@ Shared remediation rules:
 
 - preview and apply remain separate
 - selection may target a single row, selected rows, or all eligible rows in one class
-- DB cleanup and `.fuse_hidden*` deletion stay separate flows and must not be mixed in one ambiguous handler
+- DB cleanup, DB path-fix, zero-byte deletion, and `.fuse_hidden*` deletion stay separate flows and must not be mixed in one ambiguous handler
 - scan time remains non-destructive
 
 CLI and UI:

--- a/immich_doctor/adapters/external_tools.py
+++ b/immich_doctor/adapters/external_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from pathlib import Path
 
 from immich_doctor.core.models import CheckResult, CheckStatus
 
@@ -93,3 +94,60 @@ class ExternalToolsAdapter:
             message=f"Required external tool `{tool}` is available in the runtime.",
             details=details,
         )
+
+    def inspect_open_file_handles(self, path: Path) -> dict[str, object]:
+        tool = "lsof"
+        location = shutil.which(tool)
+        if not location:
+            return {
+                "status": "unavailable",
+                "tool": tool,
+                "reason": f"Required external tool `{tool}` is not available on PATH.",
+            }
+
+        try:
+            probe = subprocess.run(
+                [location, str(path)],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except OSError as exc:
+            return {
+                "status": "failed",
+                "tool": tool,
+                "reason": f"External tool `{tool}` could not be executed: {exc}",
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "status": "failed",
+                "tool": tool,
+                "reason": f"External tool `{tool}` did not respond in time.",
+            }
+
+        if probe.returncode == 0:
+            lines = [line for line in probe.stdout.splitlines() if line.strip()]
+            return {
+                "status": "in_use",
+                "tool": tool,
+                "reason": "Open file handles were detected for the path.",
+                "stdout": probe.stdout,
+                "handle_count": max(len(lines) - 1, 1),
+            }
+        if probe.returncode == 1:
+            return {
+                "status": "not_in_use",
+                "tool": tool,
+                "reason": "No open file handles were reported for the path.",
+            }
+        return {
+            "status": "failed",
+            "tool": tool,
+            "reason": (
+                f"External tool `{tool}` returned a non-zero status while inspecting the path."
+            ),
+            "stdout": probe.stdout,
+            "stderr": probe.stderr,
+            "returncode": probe.returncode,
+        }

--- a/immich_doctor/adapters/filesystem.py
+++ b/immich_doctor/adapters/filesystem.py
@@ -42,6 +42,9 @@ class FilesystemAdapter:
         with path.open("rb") as handle:
             return handle.read(size)
 
+    def delete_file(self, path: Path) -> None:
+        path.unlink()
+
     def add_read_permissions(self, path: Path) -> None:
         current_mode = path.stat().st_mode
         path.chmod(current_mode | stat.S_IRUSR | stat.S_IRGRP)

--- a/immich_doctor/adapters/filesystem.py
+++ b/immich_doctor/adapters/filesystem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import hashlib
 import os
 import shutil
 import stat
@@ -44,6 +45,22 @@ class FilesystemAdapter:
 
     def delete_file(self, path: Path) -> None:
         path.unlink()
+
+    def compute_file_checksum(
+        self,
+        path: Path,
+        *,
+        algorithm: str = "sha256",
+        chunk_size: int = 1024 * 1024,
+    ) -> str:
+        digest = hashlib.new(algorithm)
+        with path.open("rb") as handle:
+            while True:
+                chunk = handle.read(chunk_size)
+                if not chunk:
+                    break
+                digest.update(chunk)
+        return digest.hexdigest()
 
     def add_read_permissions(self, path: Path) -> None:
         current_mode = path.stat().st_mode

--- a/immich_doctor/adapters/postgres.py
+++ b/immich_doctor/adapters/postgres.py
@@ -355,21 +355,48 @@ class PostgresAdapter:
         dsn: str,
         timeout_seconds: int,
     ) -> list[dict[str, object]]:
+        asset_columns = {
+            str(row["column_name"])
+            for row in self.list_columns(
+                dsn,
+                timeout_seconds,
+                table_schema="public",
+                table_name="asset",
+            )
+        }
+        optional_columns = [
+            column
+            for column in ("checksum", "originalChecksum", "checksumAlgorithm")
+            if column in asset_columns
+        ]
+        select_columns: list[sql.Composable] = [
+            sql.SQL("id"),
+            sql.SQL("type"),
+            sql.SQL('"ownerId" AS "ownerId"'),
+            sql.SQL('"createdAt" AS "createdAt"'),
+            sql.SQL('"updatedAt" AS "updatedAt"'),
+            sql.SQL('"originalFileName" AS "originalFileName"'),
+            sql.SQL('"originalPath" AS "originalPath"'),
+            sql.SQL('"encodedVideoPath" AS "encodedVideoPath"'),
+        ]
+        for column in optional_columns:
+            select_columns.append(
+                sql.SQL("{column} AS {alias}").format(
+                    column=sql.Identifier(column),
+                    alias=sql.Identifier(column),
+                )
+            )
         query = sql.SQL(
             """
             SELECT
-                id,
-                type,
-                "ownerId" AS "ownerId",
-                "createdAt" AS "createdAt",
-                "updatedAt" AS "updatedAt",
-                "originalFileName" AS "originalFileName",
-                "originalPath" AS "originalPath",
-                "encodedVideoPath" AS "encodedVideoPath"
+                {select_columns}
             FROM {asset_table}
             ORDER BY id ASC;
             """
-        ).format(asset_table=sql.Identifier("public", "asset"))
+        ).format(
+            select_columns=sql.SQL(", ").join(select_columns),
+            asset_table=sql.Identifier("public", "asset"),
+        )
         return fetch_all_composed(dsn, timeout_seconds, query)
 
     def list_all_asset_files_for_catalog_consistency(
@@ -752,3 +779,43 @@ class PostgresAdapter:
         if not rows:
             return 0
         return int(rows[0]["deleted_count"])
+
+    def update_asset_original_path(
+        self,
+        dsn: str,
+        timeout_seconds: int,
+        *,
+        asset_id: str,
+        new_original_path: str,
+    ) -> dict[str, object]:
+        query = sql.SQL(
+            """
+            WITH previous AS (
+                SELECT id, "originalPath" AS "oldOriginalPath"
+                FROM {asset_table}
+                WHERE id = %s
+            ),
+            updated AS (
+                UPDATE {asset_table}
+                SET "originalPath" = %s
+                WHERE id = %s
+                RETURNING id, "originalPath" AS "newOriginalPath"
+            )
+            SELECT
+                updated.id,
+                previous."oldOriginalPath",
+                updated."newOriginalPath"
+            FROM updated
+            JOIN previous
+              ON previous.id = updated.id;
+            """
+        ).format(asset_table=sql.Identifier("public", "asset"))
+        rows = execute_returning_all_composed(
+            dsn,
+            timeout_seconds,
+            query,
+            (asset_id, new_original_path, asset_id),
+        )
+        if not rows:
+            raise ValueError("Asset originalPath update returned no rows.")
+        return dict(rows[0])

--- a/immich_doctor/adapters/postgres.py
+++ b/immich_doctor/adapters/postgres.py
@@ -366,7 +366,12 @@ class PostgresAdapter:
         }
         optional_columns = [
             column
-            for column in ("checksum", "originalChecksum", "checksumAlgorithm")
+            for column in (
+                "checksum",
+                "originalChecksum",
+                "checksumAlgorithm",
+                "livePhotoVideoId",
+            )
             if column in asset_columns
         ]
         select_columns: list[sql.Composable] = [

--- a/immich_doctor/api/models.py
+++ b/immich_doctor/api/models.py
@@ -149,6 +149,24 @@ class MissingAssetRestorePointDeleteApiResponse(BaseModel):
     mocked: bool = False
 
 
+class CatalogRemediationScanApiResponse(BaseModel):
+    data: dict[str, Any]
+    source: Literal["backend"] = "backend"
+    mocked: bool = False
+
+
+class CatalogRemediationPreviewApiResponse(BaseModel):
+    data: dict[str, Any]
+    source: Literal["backend"] = "backend"
+    mocked: bool = False
+
+
+class CatalogRemediationApplyApiResponse(BaseModel):
+    data: dict[str, Any]
+    source: Literal["backend"] = "backend"
+    mocked: bool = False
+
+
 class RepairRunsApiResponse(BaseModel):
     data: dict[str, Any]
     source: Literal["backend"] = "backend"

--- a/immich_doctor/api/routes/consistency.py
+++ b/immich_doctor/api/routes/consistency.py
@@ -5,6 +5,9 @@ from pydantic import AliasChoices, BaseModel, Field
 
 from immich_doctor.api.models import (
     CatalogConsistencyJobApiResponse,
+    CatalogRemediationApplyApiResponse,
+    CatalogRemediationPreviewApiResponse,
+    CatalogRemediationScanApiResponse,
     MissingAssetApplyApiResponse,
     MissingAssetPreviewApiResponse,
     MissingAssetRestoreApiResponse,
@@ -12,6 +15,7 @@ from immich_doctor.api.models import (
     MissingAssetRestorePointsApiResponse,
     MissingAssetScanApiResponse,
 )
+from immich_doctor.catalog.remediation_service import CatalogRemediationService
 from immich_doctor.catalog.workflow_service import CatalogWorkflowService
 from immich_doctor.consistency.missing_asset_service import MissingAssetReferenceService
 from immich_doctor.core.config import load_settings
@@ -48,6 +52,20 @@ class MissingAssetDeleteRestorePointsRequest(BaseModel):
 
 class CatalogConsistencyJobRequest(BaseModel):
     force: bool = False
+
+
+class CatalogRemediationBrokenPreviewRequest(BaseModel):
+    asset_ids: list[str] = Field(default_factory=list)
+    select_all: bool = False
+
+
+class CatalogRemediationFusePreviewRequest(BaseModel):
+    finding_ids: list[str] = Field(default_factory=list)
+    select_all: bool = False
+
+
+class CatalogRemediationApplyRequest(BaseModel):
+    repair_run_id: str
 
 
 @consistency_router.get(
@@ -154,6 +172,71 @@ def delete_missing_asset_restore_points(
         .to_dict()
     )
     return MissingAssetRestorePointDeleteApiResponse(data=data)
+
+
+@consistency_router.get(
+    "/catalog-remediation/findings",
+    response_model=CatalogRemediationScanApiResponse,
+)
+def scan_catalog_remediation_findings() -> CatalogRemediationScanApiResponse:
+    data = CatalogRemediationService().scan(load_settings()).to_dict()
+    return CatalogRemediationScanApiResponse(data=data)
+
+
+@consistency_router.post(
+    "/catalog-remediation/broken-db-originals/preview",
+    response_model=CatalogRemediationPreviewApiResponse,
+)
+def preview_broken_db_original_remediation(
+    payload: CatalogRemediationBrokenPreviewRequest,
+) -> CatalogRemediationPreviewApiResponse:
+    data = (
+        CatalogRemediationService()
+        .preview_broken_db_originals(
+            load_settings(),
+            asset_ids=tuple(payload.asset_ids),
+            select_all=payload.select_all,
+        )
+        .to_dict()
+    )
+    return CatalogRemediationPreviewApiResponse(data=data)
+
+
+@consistency_router.post(
+    "/catalog-remediation/fuse-hidden-orphans/preview",
+    response_model=CatalogRemediationPreviewApiResponse,
+)
+def preview_fuse_hidden_remediation(
+    payload: CatalogRemediationFusePreviewRequest,
+) -> CatalogRemediationPreviewApiResponse:
+    data = (
+        CatalogRemediationService()
+        .preview_fuse_hidden_orphans(
+            load_settings(),
+            finding_ids=tuple(payload.finding_ids),
+            select_all=payload.select_all,
+        )
+        .to_dict()
+    )
+    return CatalogRemediationPreviewApiResponse(data=data)
+
+
+@consistency_router.post(
+    "/catalog-remediation/apply",
+    response_model=CatalogRemediationApplyApiResponse,
+)
+def apply_catalog_remediation(
+    payload: CatalogRemediationApplyRequest,
+) -> CatalogRemediationApplyApiResponse:
+    data = (
+        CatalogRemediationService()
+        .apply(
+            load_settings(),
+            repair_run_id=payload.repair_run_id,
+        )
+        .to_dict()
+    )
+    return CatalogRemediationApplyApiResponse(data=data)
 
 
 @consistency_router.get("/catalog", response_model=CatalogConsistencyJobApiResponse)

--- a/immich_doctor/api/routes/consistency.py
+++ b/immich_doctor/api/routes/consistency.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from pydantic import AliasChoices, BaseModel, Field
 
 from immich_doctor.api.models import (
@@ -21,6 +21,7 @@ from immich_doctor.consistency.missing_asset_service import MissingAssetReferenc
 from immich_doctor.core.config import load_settings
 
 consistency_router = APIRouter(prefix="/consistency", tags=["consistency"])
+_CLASSIFICATION_QUERY = Query(default=None)
 
 
 class MissingAssetPreviewRequest(BaseModel):
@@ -60,6 +61,11 @@ class CatalogRemediationBrokenPreviewRequest(BaseModel):
 
 
 class CatalogRemediationFusePreviewRequest(BaseModel):
+    finding_ids: list[str] = Field(default_factory=list)
+    select_all: bool = False
+
+
+class CatalogRemediationZeroBytePreviewRequest(BaseModel):
     finding_ids: list[str] = Field(default_factory=list)
     select_all: bool = False
 
@@ -178,8 +184,17 @@ def delete_missing_asset_restore_points(
     "/catalog-remediation/findings",
     response_model=CatalogRemediationScanApiResponse,
 )
-def scan_catalog_remediation_findings() -> CatalogRemediationScanApiResponse:
-    data = CatalogRemediationService().scan(load_settings()).to_dict()
+def scan_catalog_remediation_findings(
+    classification: list[str] | None = _CLASSIFICATION_QUERY,
+) -> CatalogRemediationScanApiResponse:
+    data = (
+        CatalogRemediationService()
+        .scan(
+            load_settings(),
+            classifications=tuple(classification or []),
+        )
+        .to_dict()
+    )
     return CatalogRemediationScanApiResponse(data=data)
 
 
@@ -192,9 +207,47 @@ def preview_broken_db_original_remediation(
 ) -> CatalogRemediationPreviewApiResponse:
     data = (
         CatalogRemediationService()
-        .preview_broken_db_originals(
+        .preview_broken_db_cleanup(
             load_settings(),
             asset_ids=tuple(payload.asset_ids),
+            select_all=payload.select_all,
+        )
+        .to_dict()
+    )
+    return CatalogRemediationPreviewApiResponse(data=data)
+
+
+@consistency_router.post(
+    "/catalog-remediation/broken-db-originals/path-fix/preview",
+    response_model=CatalogRemediationPreviewApiResponse,
+)
+def preview_broken_db_path_fix_remediation(
+    payload: CatalogRemediationBrokenPreviewRequest,
+) -> CatalogRemediationPreviewApiResponse:
+    data = (
+        CatalogRemediationService()
+        .preview_broken_db_path_fix(
+            load_settings(),
+            asset_ids=tuple(payload.asset_ids),
+            select_all=payload.select_all,
+        )
+        .to_dict()
+    )
+    return CatalogRemediationPreviewApiResponse(data=data)
+
+
+@consistency_router.post(
+    "/catalog-remediation/zero-byte-files/preview",
+    response_model=CatalogRemediationPreviewApiResponse,
+)
+def preview_zero_byte_remediation(
+    payload: CatalogRemediationZeroBytePreviewRequest,
+) -> CatalogRemediationPreviewApiResponse:
+    data = (
+        CatalogRemediationService()
+        .preview_zero_byte_files(
+            load_settings(),
+            finding_ids=tuple(payload.finding_ids),
             select_all=payload.select_all,
         )
         .to_dict()

--- a/immich_doctor/catalog/consistency_service.py
+++ b/immich_doctor/catalog/consistency_service.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from immich_doctor.adapters.postgres import PostgresAdapter
-from immich_doctor.catalog.service import CatalogRootRegistry
-from immich_doctor.catalog.store import CatalogStore
+from immich_doctor.catalog.consistency_state import (
+    DB_MISSING_SECTION,
+    ORPHAN_SECTION,
+    STORAGE_MISSING_SECTION,
+    UNMAPPED_SECTION,
+    ZERO_BYTE_SECTION,
+    CatalogConsistencyStateCollector,
+)
 from immich_doctor.core.config import AppSettings
 from immich_doctor.core.models import (
     CheckResult,
@@ -14,22 +19,8 @@ from immich_doctor.core.models import (
     ValidationReport,
     ValidationSection,
 )
-from immich_doctor.storage.path_mapping import ImmichStoragePathResolver
 
-_ZERO_BYTE_SECTION = "ZERO_BYTE_FILES"
-_DB_MISSING_SECTION = "DB_ORIGINALS_MISSING_ON_STORAGE"
-_STORAGE_MISSING_SECTION = "STORAGE_ORIGINALS_MISSING_IN_DB"
-_ORPHAN_SECTION = "ORPHAN_DERIVATIVES_WITHOUT_ORIGINAL"
-_UNMAPPED_SECTION = "UNMAPPED_DATABASE_PATHS"
-_SOURCE_ROOT_SLUG = "uploads"
-_DERIVATIVE_ROOT_SLUGS = {"thumbs", "profile", "video"}
-_SIDECAR_EXTENSION = ".xmp"
 _DEFAULT_SAMPLE_LIMIT = 200
-
-
-def _truthy_path(value: object) -> str | None:
-    text = str(value or "").strip()
-    return text or None
 
 
 def _section_status(rows: list[dict[str, object]]) -> CheckStatus:
@@ -38,8 +29,6 @@ def _section_status(rows: list[dict[str, object]]) -> CheckStatus:
 
 @dataclass(slots=True)
 class CatalogConsistencyValidationService:
-    store: CatalogStore = field(default_factory=CatalogStore)
-    registry: CatalogRootRegistry = field(default_factory=CatalogRootRegistry)
     postgres: PostgresAdapter = field(default_factory=PostgresAdapter)
     sample_limit: int = _DEFAULT_SAMPLE_LIMIT
 
@@ -49,55 +38,10 @@ class CatalogConsistencyValidationService:
         *,
         progress_callback: Callable[[dict[str, object]], None] | None = None,
     ) -> ValidationReport:
-        synced_roots = self.registry.sync(settings)
-        effective_root_slugs = [root.slug for root in self.registry.scan_roots(settings)]
-        latest_snapshots = self.store.list_latest_snapshots(settings)
-        snapshot_by_slug = {
-            str(row["root_slug"]): row
-            for row in latest_snapshots
-            if row.get("snapshot_id") is not None and bool(row.get("snapshot_current"))
-        }
-        stale_root_slugs = sorted(
-            [
-                str(row["root_slug"])
-                for row in latest_snapshots
-                if row.get("snapshot_id") is not None
-                and not bool(row.get("snapshot_current"))
-                and str(row["root_slug"]) in effective_root_slugs
-            ]
-        )
-        missing_root_slugs = [
-            slug
-            for slug in effective_root_slugs
-            if slug not in snapshot_by_slug and slug not in stale_root_slugs
-        ]
-        checks = [
-            CheckResult(
-                name="catalog_configured_roots",
-                status=CheckStatus.PASS if synced_roots else CheckStatus.FAIL,
-                message=(
-                    f"Found {len(synced_roots)} configured catalog roots."
-                    if synced_roots
-                    else "No catalog roots are configured."
-                ),
-            )
-        ]
-        if missing_root_slugs or stale_root_slugs:
-            checks.append(
-                CheckResult(
-                    name="catalog_current_snapshots",
-                    status=CheckStatus.FAIL,
-                    message=(
-                        "Current committed catalog snapshots are not available for every "
-                        "effective storage root. Run a catalog scan first."
-                    ),
-                    details={
-                        "effective_root_slugs": effective_root_slugs,
-                        "missing_root_slugs": missing_root_slugs,
-                        "stale_root_slugs": stale_root_slugs,
-                    },
-                )
-            )
+        collector = CatalogConsistencyStateCollector(postgres=self.postgres)
+        snapshot_state = collector.prepare_snapshot_state(settings)
+        checks = list(snapshot_state.checks)
+        if not snapshot_state.ready:
             return ValidationReport(
                 domain="consistency.catalog",
                 action="validate",
@@ -105,13 +49,7 @@ class CatalogConsistencyValidationService:
                     "Catalog-backed consistency is waiting for a current committed storage index."
                 ),
                 checks=checks,
-                metadata={
-                    "configuredRoots": effective_root_slugs,
-                    "latestSnapshots": latest_snapshots,
-                    "staleRootSlugs": stale_root_slugs,
-                    "missingRootSlugs": missing_root_slugs,
-                    "requiresCurrentScan": True,
-                },
+                metadata=snapshot_state.metadata,
                 recommendations=[
                     "Run a catalog scan from the Storage page before starting the "
                     "consistency validation.",
@@ -120,26 +58,25 @@ class CatalogConsistencyValidationService:
 
         dsn = settings.postgres_dsn_value()
         if not dsn:
-            checks.append(
-                CheckResult(
-                    name="postgres_connection",
-                    status=CheckStatus.FAIL,
-                    message="Database DSN is not configured.",
-                )
-            )
             return ValidationReport(
                 domain="consistency.catalog",
                 action="validate",
                 summary=(
                     "Catalog-backed consistency failed because database access is not configured."
                 ),
-                checks=checks,
-                metadata={"latestSnapshots": latest_snapshots},
+                checks=[
+                    *checks,
+                    CheckResult(
+                        name="postgres_connection",
+                        status=CheckStatus.FAIL,
+                        message="Database DSN is not configured.",
+                    ),
+                ],
+                metadata={"latestSnapshots": snapshot_state.latest_snapshots},
             )
 
         timeout = settings.postgres_connect_timeout_seconds
         connection_check = self.postgres.validate_connection(dsn, timeout)
-        checks.append(connection_check)
         if connection_check.status == CheckStatus.FAIL:
             return ValidationReport(
                 domain="consistency.catalog",
@@ -147,327 +84,91 @@ class CatalogConsistencyValidationService:
                 summary=(
                     "Catalog-backed consistency failed because PostgreSQL could not be reached."
                 ),
-                checks=checks,
-                metadata={"latestSnapshots": latest_snapshots},
+                checks=[*checks, connection_check],
+                metadata={"latestSnapshots": snapshot_state.latest_snapshots},
             )
 
-        resolver = ImmichStoragePathResolver(settings)
-        zero_byte_rows = self.store.list_zero_byte_files(settings, limit=self.sample_limit)
-        latest_files = self.store.list_latest_snapshot_files(settings)
-        files_by_root: dict[str, list[dict[str, object]]] = defaultdict(list)
-        for row in latest_files:
-            files_by_root[str(row["root_slug"])].append(row)
-
-        uploads_rows = files_by_root.get(_SOURCE_ROOT_SLUG, [])
-        uploads_index = {str(row["relative_path"]) for row in uploads_rows}
-        source_only_rows = [row for row in uploads_rows if self._is_original_candidate(row)]
-        derivative_indexes = {
-            slug: {str(row["relative_path"]) for row in rows}
-            for slug, rows in files_by_root.items()
-            if slug in _DERIVATIVE_ROOT_SLUGS or slug == _SOURCE_ROOT_SLUG
-        }
-
-        if progress_callback is not None:
-            progress_callback(
-                {
-                    "phase": "catalog",
-                    "current": 1,
-                    "total": 4,
-                    "percent": 25.0,
-                    "message": "Loaded persisted catalog snapshots.",
-                    "filesIndexed": len(latest_files),
-                }
-            )
-
-        asset_rows = self.postgres.list_all_assets_for_catalog_consistency(dsn, timeout)
-        asset_file_rows = self.postgres.list_all_asset_files_for_catalog_consistency(
-            dsn,
-            timeout,
-        )
-
-        db_missing_rows: list[dict[str, object]] = []
-        storage_missing_rows: list[dict[str, object]] = []
-        orphan_rows: list[dict[str, object]] = []
-        unmapped_rows: list[dict[str, object]] = []
-        db_original_index: set[str] = set()
-        original_by_asset: dict[str, str] = {}
-        derivative_rows_by_asset: dict[str, list[dict[str, object]]] = defaultdict(list)
-
-        for row in asset_file_rows:
-            derivative_rows_by_asset[str(row["assetId"])].append(row)
-
-        for index, asset in enumerate(asset_rows, start=1):
-            asset_id = str(asset["id"])
-            original_path = _truthy_path(asset.get("originalPath"))
-            if not original_path:
-                continue
-            asset_name = _truthy_path(asset.get("originalFileName"))
-
-            resolved_original = resolver.resolve(original_path)
-            if resolved_original is None:
-                unmapped_rows.append(
-                    {
-                        "asset_id": asset_id,
-                        "asset_name": asset_name,
-                        "path_kind": "original",
-                        "database_path": original_path,
-                        "mapping_status": (
-                            "legacy_path_unmapped"
-                            if resolver.looks_like_legacy_immich_path(original_path)
-                            else "unrecognized_path"
-                        ),
-                    }
-                )
-                continue
-
-            if resolved_original.root_slug != _SOURCE_ROOT_SLUG:
-                unmapped_rows.append(
-                    {
-                        "asset_id": asset_id,
-                        "asset_name": asset_name,
-                        "path_kind": "original",
-                        "database_path": original_path,
-                        "mapping_status": "unexpected_root",
-                        "resolved_root": resolved_original.root_slug,
-                        "mapping_mode": resolved_original.mapping_mode,
-                    }
-                )
-                continue
-
-            db_original_index.add(resolved_original.relative_path)
-            original_by_asset[asset_id] = resolved_original.relative_path
-            if resolved_original.relative_path not in uploads_index:
-                db_missing_rows.append(
-                    {
-                        "asset_id": asset_id,
-                        "asset_name": asset_name,
-                        "asset_type": asset.get("type"),
-                        "database_path": original_path,
-                        "resolved_root": resolved_original.root_slug,
-                        "relative_path": resolved_original.relative_path,
-                        "mapping_mode": resolved_original.mapping_mode,
-                    }
-                )
-
-            if progress_callback is not None and index % 2500 == 0:
-                progress_callback(
-                    {
-                        "phase": "database-originals",
-                        "current": index,
-                        "total": len(asset_rows),
-                        "percent": round(25 + (index / max(len(asset_rows), 1)) * 25, 2),
-                        "message": ("Compared DB original paths against the cached uploads index."),
-                        "dbMissingCount": len(db_missing_rows),
-                        "unmappedCount": len(unmapped_rows),
-                    }
-                )
-
-        for row in source_only_rows:
-            relative_path = str(row["relative_path"])
-            if relative_path in db_original_index:
-                continue
-            storage_missing_rows.append(
-                {
-                    "root_slug": row["root_slug"],
-                    "relative_path": relative_path,
-                    "file_name": row["file_name"],
-                    "size_bytes": row["size_bytes"],
-                    "snapshot_id": row["snapshot_id"],
-                    "generation": row["generation"],
-                }
-            )
-
-        if progress_callback is not None:
-            progress_callback(
-                {
-                    "phase": "storage-originals",
-                    "current": len(source_only_rows),
-                    "total": len(source_only_rows),
-                    "percent": 75.0,
-                    "message": ("Compared cached storage originals against DB original paths."),
-                    "storageMissingCount": len(storage_missing_rows),
-                }
-            )
-
-        orphan_keys: set[tuple[str, str, str]] = set()
-        for asset in asset_rows:
-            asset_id = str(asset["id"])
-            original_relative_path = original_by_asset.get(asset_id)
-            if original_relative_path is None or original_relative_path in uploads_index:
-                continue
-
-            encoded_video_path = _truthy_path(asset.get("encodedVideoPath"))
-            if encoded_video_path:
-                self._append_orphan_row(
-                    orphan_rows,
-                    orphan_keys,
-                    asset_id=asset_id,
-                    derivative_type="encoded_video",
-                    resolver=resolver,
-                    path_text=encoded_video_path,
-                    derivative_indexes=derivative_indexes,
-                    original_relative_path=original_relative_path,
-                )
-
-            for derivative in derivative_rows_by_asset.get(asset_id, []):
-                self._append_orphan_row(
-                    orphan_rows,
-                    orphan_keys,
-                    asset_id=asset_id,
-                    derivative_type=str(derivative["type"]),
-                    resolver=resolver,
-                    path_text=str(derivative["path"]),
-                    derivative_indexes=derivative_indexes,
-                    original_relative_path=original_relative_path,
-                )
-
-        if progress_callback is not None:
-            progress_callback(
-                {
-                    "phase": "orphans",
-                    "current": len(orphan_rows),
-                    "total": len(orphan_rows),
-                    "percent": 100.0,
-                    "message": (
-                        "Derived orphan derivative findings from the cached catalog and DB graph."
-                    ),
-                    "orphanCount": len(orphan_rows),
-                }
-            )
-
-        derivative_snapshot_coverage = sorted(
-            slug
-            for slug in snapshot_by_slug
-            if slug in _DERIVATIVE_ROOT_SLUGS or slug == _SOURCE_ROOT_SLUG
-        )
-        checks.append(
-            CheckResult(
-                name="catalog_snapshot_coverage",
-                status=CheckStatus.PASS if derivative_snapshot_coverage else CheckStatus.WARN,
-                message=(
-                    "Committed catalog snapshots are available for the required storage roots."
-                    if derivative_snapshot_coverage
-                    else "Only a partial set of catalog snapshots is available."
-                ),
-                details={"roots": derivative_snapshot_coverage},
-            )
-        )
-        checks.append(
-            CheckResult(
-                name="catalog_path_mapping",
-                status=CheckStatus.WARN if unmapped_rows else CheckStatus.PASS,
-                message=(
-                    (
-                        f"{len(unmapped_rows)} database paths could not be "
-                        "mapped into configured runtime roots."
-                    )
-                    if unmapped_rows
-                    else "Database paths mapped cleanly into configured runtime roots."
-                ),
-            )
-        )
-
-        sampled_db_missing = db_missing_rows[: self.sample_limit]
-        sampled_storage_missing = storage_missing_rows[: self.sample_limit]
-        sampled_orphans = orphan_rows[: self.sample_limit]
-        sampled_unmapped = unmapped_rows[: self.sample_limit]
+        state = collector.collect(settings, progress_callback=progress_callback)
+        sampled_db_missing = state.db_missing_rows[: self.sample_limit]
+        sampled_storage_missing = state.storage_missing_rows[: self.sample_limit]
+        sampled_orphans = state.orphan_rows[: self.sample_limit]
+        sampled_unmapped = state.unmapped_rows[: self.sample_limit]
 
         summary = (
             "Catalog-backed consistency compared the cached storage inventory "
             "against the live database: "
-            f"{len(db_missing_rows)} DB originals not found in the current storage snapshot, "
-            f"{len(storage_missing_rows)} storage originals missing in DB, "
-            f"{len(orphan_rows)} orphan derivatives, and "
-            f"{len(zero_byte_rows)} zero-byte findings."
-        )
-
-        snapshot_basis = [
-            {
-                "rootSlug": str(row["root_slug"]),
-                "snapshotId": row["snapshot_id"],
-                "generation": row["generation"],
-                "committedAt": row["committed_at"],
-                "absolutePath": row["absolute_path"],
-            }
-            for row in latest_snapshots
-            if row.get("snapshot_id") is not None
-            and bool(row.get("snapshot_current"))
-            and str(row["root_slug"]) in effective_root_slugs
-        ]
-        latest_scan_committed_at = max(
-            (
-                str(row["committed_at"])
-                for row in latest_snapshots
-                if row.get("committed_at")
-                and bool(row.get("snapshot_current"))
-                and str(row["root_slug"]) in effective_root_slugs
-            ),
-            default=None,
+            f"{len(state.db_missing_rows)} DB originals not found in the current storage snapshot, "
+            f"{len(state.storage_missing_rows)} storage originals missing in DB, "
+            f"{len(state.orphan_rows)} orphan derivatives, and "
+            f"{len(state.zero_byte_rows)} zero-byte findings."
         )
 
         return ValidationReport(
             domain="consistency.catalog",
             action="validate",
             summary=summary,
-            checks=checks,
+            checks=state.checks,
             sections=[
                 ValidationSection(
-                    name=_DB_MISSING_SECTION,
-                    status=_section_status(db_missing_rows),
+                    name=DB_MISSING_SECTION,
+                    status=_section_status(state.db_missing_rows),
                     rows=sampled_db_missing,
                 ),
                 ValidationSection(
-                    name=_STORAGE_MISSING_SECTION,
-                    status=_section_status(storage_missing_rows),
+                    name=STORAGE_MISSING_SECTION,
+                    status=_section_status(state.storage_missing_rows),
                     rows=sampled_storage_missing,
                 ),
                 ValidationSection(
-                    name=_ORPHAN_SECTION,
-                    status=_section_status(orphan_rows),
+                    name=ORPHAN_SECTION,
+                    status=_section_status(state.orphan_rows),
                     rows=sampled_orphans,
                 ),
                 ValidationSection(
-                    name=_ZERO_BYTE_SECTION,
-                    status=_section_status(zero_byte_rows[: self.sample_limit]),
-                    rows=zero_byte_rows[: self.sample_limit],
+                    name=ZERO_BYTE_SECTION,
+                    status=_section_status(state.zero_byte_rows[: self.sample_limit]),
+                    rows=state.zero_byte_rows[: self.sample_limit],
                 ),
                 ValidationSection(
-                    name=_UNMAPPED_SECTION,
-                    status=CheckStatus.WARN if unmapped_rows else CheckStatus.PASS,
+                    name=UNMAPPED_SECTION,
+                    status=CheckStatus.WARN if state.unmapped_rows else CheckStatus.PASS,
                     rows=sampled_unmapped,
                 ),
             ],
             metrics=[
-                {"name": "db_originals_missing_on_storage", "value": len(db_missing_rows)},
+                {
+                    "name": "db_originals_missing_on_storage",
+                    "value": len(state.db_missing_rows),
+                },
                 {
                     "name": "storage_originals_missing_in_db",
-                    "value": len(storage_missing_rows),
+                    "value": len(state.storage_missing_rows),
                 },
                 {
                     "name": "orphan_derivatives_without_original",
-                    "value": len(orphan_rows),
+                    "value": len(state.orphan_rows),
                 },
-                {"name": "zero_byte_files", "value": len(zero_byte_rows)},
-                {"name": "unmapped_database_paths", "value": len(unmapped_rows)},
+                {"name": "zero_byte_files", "value": len(state.zero_byte_rows)},
+                {"name": "unmapped_database_paths", "value": len(state.unmapped_rows)},
             ],
             metadata={
-                "configuredRoots": [row["slug"] for row in synced_roots],
-                "latestSnapshots": latest_snapshots,
-                "snapshotBasis": snapshot_basis,
-                "latestScanCommittedAt": latest_scan_committed_at,
+                "configuredRoots": state.configured_root_slugs,
+                "latestSnapshots": state.latest_snapshots,
+                "snapshotBasis": state.snapshot_basis,
+                "latestScanCommittedAt": state.latest_scan_committed_at,
                 "sampleLimit": self.sample_limit,
                 "totals": {
-                    "dbOriginalsMissingOnStorage": len(db_missing_rows),
-                    "storageOriginalsMissingInDb": len(storage_missing_rows),
-                    "orphanDerivativesWithoutOriginal": len(orphan_rows),
-                    "zeroByteFiles": len(zero_byte_rows),
-                    "unmappedDatabasePaths": len(unmapped_rows),
+                    "dbOriginalsMissingOnStorage": len(state.db_missing_rows),
+                    "storageOriginalsMissingInDb": len(state.storage_missing_rows),
+                    "orphanDerivativesWithoutOriginal": len(state.orphan_rows),
+                    "zeroByteFiles": len(state.zero_byte_rows),
+                    "unmappedDatabasePaths": len(state.unmapped_rows),
                 },
                 "truncated": {
-                    _DB_MISSING_SECTION: len(db_missing_rows) > self.sample_limit,
-                    _STORAGE_MISSING_SECTION: len(storage_missing_rows) > self.sample_limit,
-                    _ORPHAN_SECTION: len(orphan_rows) > self.sample_limit,
-                    _UNMAPPED_SECTION: len(unmapped_rows) > self.sample_limit,
+                    DB_MISSING_SECTION: len(state.db_missing_rows) > self.sample_limit,
+                    STORAGE_MISSING_SECTION: len(state.storage_missing_rows) > self.sample_limit,
+                    ORPHAN_SECTION: len(state.orphan_rows) > self.sample_limit,
+                    UNMAPPED_SECTION: len(state.unmapped_rows) > self.sample_limit,
                 },
             },
             recommendations=[
@@ -475,43 +176,4 @@ class CatalogConsistencyValidationService:
                 "Use the catalog-backed counts as cached storage truth before "
                 "starting any destructive workflow.",
             ],
-        )
-
-    def _is_original_candidate(self, row: dict[str, object]) -> bool:
-        extension = str(row.get("extension") or "").lower()
-        relative_path = str(row.get("relative_path") or "")
-        if extension == _SIDECAR_EXTENSION:
-            return False
-        return not relative_path.endswith(_SIDECAR_EXTENSION)
-
-    def _append_orphan_row(
-        self,
-        orphan_rows: list[dict[str, object]],
-        orphan_keys: set[tuple[str, str, str]],
-        *,
-        asset_id: str,
-        derivative_type: str,
-        resolver: ImmichStoragePathResolver,
-        path_text: str,
-        derivative_indexes: dict[str, set[str]],
-        original_relative_path: str,
-    ) -> None:
-        resolved = resolver.resolve(path_text)
-        if resolved is None:
-            return
-        if resolved.relative_path not in derivative_indexes.get(resolved.root_slug, set()):
-            return
-        key = (asset_id, derivative_type, resolved.relative_path)
-        if key in orphan_keys:
-            return
-        orphan_keys.add(key)
-        orphan_rows.append(
-            {
-                "asset_id": asset_id,
-                "derivative_type": derivative_type,
-                "root_slug": resolved.root_slug,
-                "relative_path": resolved.relative_path,
-                "database_path": path_text,
-                "original_relative_path": original_relative_path,
-            }
         )

--- a/immich_doctor/catalog/consistency_service.py
+++ b/immich_doctor/catalog/consistency_service.py
@@ -93,14 +93,23 @@ class CatalogConsistencyValidationService:
         sampled_storage_missing = state.storage_missing_rows[: self.sample_limit]
         sampled_orphans = state.orphan_rows[: self.sample_limit]
         sampled_unmapped = state.unmapped_rows[: self.sample_limit]
+        real_issue_count = (
+            len(state.db_missing_rows)
+            + len(state.storage_missing_rows)
+            + len(state.orphan_rows)
+            + len(state.zero_byte_rows)
+            + len(state.unmapped_rows)
+        )
 
         summary = (
             "Catalog-backed consistency compared the cached storage inventory "
-            "against the live database: "
+            "against the live database and reports only actionable inconsistencies: "
             f"{len(state.db_missing_rows)} DB originals not found in the current storage snapshot, "
             f"{len(state.storage_missing_rows)} storage originals missing in DB, "
             f"{len(state.orphan_rows)} orphan derivatives, and "
-            f"{len(state.zero_byte_rows)} zero-byte findings."
+            f"{len(state.zero_byte_rows)} zero-byte findings. "
+            f"Suppressed {state.valid_motion_video_components} valid motion video components; "
+            f"{real_issue_count} real issues remain."
         )
 
         return ValidationReport(
@@ -158,11 +167,15 @@ class CatalogConsistencyValidationService:
                 "latestScanCommittedAt": state.latest_scan_committed_at,
                 "sampleLimit": self.sample_limit,
                 "totals": {
+                    "totalAssetsScanned": state.total_assets_scanned,
                     "dbOriginalsMissingOnStorage": len(state.db_missing_rows),
                     "storageOriginalsMissingInDb": len(state.storage_missing_rows),
                     "orphanDerivativesWithoutOriginal": len(state.orphan_rows),
                     "zeroByteFiles": len(state.zero_byte_rows),
                     "unmappedDatabasePaths": len(state.unmapped_rows),
+                    "filteredNoiseRemoved": state.valid_motion_video_components,
+                    "validMotionVideoComponents": state.valid_motion_video_components,
+                    "realIssuesRemaining": real_issue_count,
                 },
                 "truncated": {
                     DB_MISSING_SECTION: len(state.db_missing_rows) > self.sample_limit,

--- a/immich_doctor/catalog/consistency_state.py
+++ b/immich_doctor/catalog/consistency_state.py
@@ -372,8 +372,7 @@ class CatalogConsistencyStateCollector:
                     "total": len(orphan_rows),
                     "percent": 100.0,
                     "message": (
-                        "Derived orphan derivative findings from the cached catalog "
-                        "and DB graph."
+                        "Derived orphan derivative findings from the cached catalog and DB graph."
                     ),
                     "orphanCount": len(orphan_rows),
                 }

--- a/immich_doctor/catalog/consistency_state.py
+++ b/immich_doctor/catalog/consistency_state.py
@@ -59,6 +59,8 @@ class CatalogConsistencyState:
     snapshot_basis: list[dict[str, object]]
     latest_scan_committed_at: str | None
     configured_root_slugs: list[str]
+    total_assets_scanned: int = 0
+    valid_motion_video_components: int = 0
     progress_metadata: dict[str, object] = field(default_factory=dict)
 
 
@@ -191,6 +193,12 @@ class CatalogConsistencyStateCollector:
 
         asset_rows = self.postgres.list_all_assets_for_catalog_consistency(dsn, timeout)
         asset_file_rows = self.postgres.list_all_asset_files_for_catalog_consistency(dsn, timeout)
+        live_photo_video_ids = {
+            str(value)
+            for asset in asset_rows
+            for value in [asset.get("livePhotoVideoId")]
+            if truthy_path(value) is not None
+        }
 
         db_missing_rows: list[dict[str, object]] = []
         storage_missing_rows: list[dict[str, object]] = []
@@ -199,6 +207,8 @@ class CatalogConsistencyStateCollector:
         db_original_index: set[str] = set()
         original_by_asset: dict[str, str] = {}
         derivative_rows_by_asset: dict[str, list[dict[str, object]]] = defaultdict(list)
+        total_assets_scanned = 0
+        valid_motion_video_components = 0
 
         for row in asset_file_rows:
             derivative_rows_by_asset[str(row["assetId"])].append(row)
@@ -208,6 +218,7 @@ class CatalogConsistencyStateCollector:
             original_path = truthy_path(asset.get("originalPath"))
             if not original_path:
                 continue
+            total_assets_scanned += 1
             asset_name = truthy_path(asset.get("originalFileName"))
 
             resolved_original = resolver.resolve(original_path)
@@ -228,6 +239,31 @@ class CatalogConsistencyStateCollector:
                 continue
 
             if resolved_original.root_slug != SOURCE_ROOT_SLUG:
+                if self._is_valid_motion_video_component(
+                    asset,
+                    original_path=original_path,
+                    resolved_root=resolved_original.root_slug,
+                    live_photo_video_ids=live_photo_video_ids,
+                ):
+                    if resolved_original.relative_path in derivative_indexes.get(
+                        resolved_original.root_slug,
+                        set(),
+                    ):
+                        valid_motion_video_components += 1
+                        continue
+                    db_missing_rows.append(
+                        {
+                            "asset_id": asset_id,
+                            "asset_name": asset_name,
+                            "asset_type": asset.get("type"),
+                            "database_path": original_path,
+                            "resolved_root": resolved_original.root_slug,
+                            "relative_path": resolved_original.relative_path,
+                            "mapping_mode": resolved_original.mapping_mode,
+                            "classification": "valid_motion_video_component_missing_on_storage",
+                        }
+                    )
+                    continue
                 unmapped_rows.append(
                     {
                         "asset_id": asset_id,
@@ -416,6 +452,8 @@ class CatalogConsistencyStateCollector:
             snapshot_basis=snapshot_basis,
             latest_scan_committed_at=latest_scan_committed_at,
             configured_root_slugs=[row["slug"] for row in snapshot_state.synced_roots],
+            total_assets_scanned=total_assets_scanned,
+            valid_motion_video_components=valid_motion_video_components,
             progress_metadata=snapshot_state.metadata,
         )
 
@@ -456,4 +494,22 @@ class CatalogConsistencyStateCollector:
                 "database_path": path_text,
                 "original_relative_path": original_relative_path,
             }
+        )
+
+    def _is_valid_motion_video_component(
+        self,
+        asset: dict[str, object],
+        *,
+        original_path: str,
+        resolved_root: str,
+        live_photo_video_ids: set[str],
+    ) -> bool:
+        asset_id = str(asset.get("id") or "").strip()
+        asset_type = str(asset.get("type") or "").strip().upper()
+        normalized_path = original_path.replace("\\", "/")
+        return (
+            resolved_root == "video"
+            and asset_type == "VIDEO"
+            and "/encoded-video/" in normalized_path
+            and asset_id in live_photo_video_ids
         )

--- a/immich_doctor/catalog/consistency_state.py
+++ b/immich_doctor/catalog/consistency_state.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from immich_doctor.adapters.postgres import PostgresAdapter
+from immich_doctor.catalog.service import CatalogRootRegistry
+from immich_doctor.catalog.store import CatalogStore
+from immich_doctor.core.config import AppSettings
+from immich_doctor.core.models import CheckResult, CheckStatus
+from immich_doctor.storage.path_mapping import ImmichStoragePathResolver
+
+ZERO_BYTE_SECTION = "ZERO_BYTE_FILES"
+DB_MISSING_SECTION = "DB_ORIGINALS_MISSING_ON_STORAGE"
+STORAGE_MISSING_SECTION = "STORAGE_ORIGINALS_MISSING_IN_DB"
+ORPHAN_SECTION = "ORPHAN_DERIVATIVES_WITHOUT_ORIGINAL"
+UNMAPPED_SECTION = "UNMAPPED_DATABASE_PATHS"
+SOURCE_ROOT_SLUG = "uploads"
+DERIVATIVE_ROOT_SLUGS = {"thumbs", "profile", "video"}
+SIDECAR_EXTENSION = ".xmp"
+
+
+def truthy_path(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+@dataclass(slots=True, frozen=True)
+class CatalogSnapshotState:
+    synced_roots: list[dict[str, object]]
+    effective_root_slugs: list[str]
+    latest_snapshots: list[dict[str, object]]
+    snapshot_by_slug: dict[str, dict[str, object]]
+    stale_root_slugs: list[str]
+    missing_root_slugs: list[str]
+    checks: list[CheckResult]
+    ready: bool
+    metadata: dict[str, object]
+
+
+@dataclass(slots=True)
+class CatalogConsistencyState:
+    checks: list[CheckResult]
+    latest_snapshots: list[dict[str, object]]
+    latest_files: list[dict[str, object]]
+    asset_rows: list[dict[str, object]]
+    asset_file_rows: list[dict[str, object]]
+    zero_byte_rows: list[dict[str, object]]
+    db_missing_rows: list[dict[str, object]]
+    storage_missing_rows: list[dict[str, object]]
+    orphan_rows: list[dict[str, object]]
+    unmapped_rows: list[dict[str, object]]
+    uploads_rows: list[dict[str, object]]
+    uploads_index: set[str]
+    db_original_index: set[str]
+    original_by_asset: dict[str, str]
+    derivative_indexes: dict[str, set[str]]
+    snapshot_basis: list[dict[str, object]]
+    latest_scan_committed_at: str | None
+    configured_root_slugs: list[str]
+    progress_metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class CatalogConsistencyStateCollector:
+    store: CatalogStore = field(default_factory=CatalogStore)
+    registry: CatalogRootRegistry = field(default_factory=CatalogRootRegistry)
+    postgres: PostgresAdapter = field(default_factory=PostgresAdapter)
+
+    def prepare_snapshot_state(self, settings: AppSettings) -> CatalogSnapshotState:
+        synced_roots = self.registry.sync(settings)
+        effective_root_slugs = [root.slug for root in self.registry.scan_roots(settings)]
+        latest_snapshots = self.store.list_latest_snapshots(settings)
+        snapshot_by_slug = {
+            str(row["root_slug"]): row
+            for row in latest_snapshots
+            if row.get("snapshot_id") is not None and bool(row.get("snapshot_current"))
+        }
+        stale_root_slugs = sorted(
+            [
+                str(row["root_slug"])
+                for row in latest_snapshots
+                if row.get("snapshot_id") is not None
+                and not bool(row.get("snapshot_current"))
+                and str(row["root_slug"]) in effective_root_slugs
+            ]
+        )
+        missing_root_slugs = [
+            slug
+            for slug in effective_root_slugs
+            if slug not in snapshot_by_slug and slug not in stale_root_slugs
+        ]
+        checks = [
+            CheckResult(
+                name="catalog_configured_roots",
+                status=CheckStatus.PASS if synced_roots else CheckStatus.FAIL,
+                message=(
+                    f"Found {len(synced_roots)} configured catalog roots."
+                    if synced_roots
+                    else "No catalog roots are configured."
+                ),
+            )
+        ]
+        ready = not (missing_root_slugs or stale_root_slugs)
+        metadata = {
+            "configuredRoots": effective_root_slugs,
+            "latestSnapshots": latest_snapshots,
+            "staleRootSlugs": stale_root_slugs,
+            "missingRootSlugs": missing_root_slugs,
+            "requiresCurrentScan": not ready,
+        }
+        if not ready:
+            checks.append(
+                CheckResult(
+                    name="catalog_current_snapshots",
+                    status=CheckStatus.FAIL,
+                    message=(
+                        "Current committed catalog snapshots are not available for every "
+                        "effective storage root. Run a catalog scan first."
+                    ),
+                    details={
+                        "effective_root_slugs": effective_root_slugs,
+                        "missing_root_slugs": missing_root_slugs,
+                        "stale_root_slugs": stale_root_slugs,
+                    },
+                )
+            )
+        return CatalogSnapshotState(
+            synced_roots=synced_roots,
+            effective_root_slugs=effective_root_slugs,
+            latest_snapshots=latest_snapshots,
+            snapshot_by_slug=snapshot_by_slug,
+            stale_root_slugs=stale_root_slugs,
+            missing_root_slugs=missing_root_slugs,
+            checks=checks,
+            ready=ready,
+            metadata=metadata,
+        )
+
+    def collect(
+        self,
+        settings: AppSettings,
+        *,
+        progress_callback: Callable[[dict[str, object]], None] | None = None,
+    ) -> CatalogConsistencyState:
+        snapshot_state = self.prepare_snapshot_state(settings)
+        if not snapshot_state.ready:
+            raise ValueError("Catalog consistency state requires current committed snapshots.")
+
+        dsn = settings.postgres_dsn_value()
+        if not dsn:
+            raise ValueError("Database DSN is required to collect catalog consistency state.")
+
+        timeout = settings.postgres_connect_timeout_seconds
+        checks = list(snapshot_state.checks)
+        connection_check = self.postgres.validate_connection(dsn, timeout)
+        checks.append(connection_check)
+        if connection_check.status == CheckStatus.FAIL:
+            raise ValueError(
+                "PostgreSQL connection is required to collect catalog consistency state."
+            )
+
+        resolver = ImmichStoragePathResolver(settings)
+        zero_byte_rows = self.store.list_zero_byte_files(settings, limit=10_000)
+        latest_files = self.store.list_latest_snapshot_files(settings)
+        files_by_root: dict[str, list[dict[str, object]]] = defaultdict(list)
+        for row in latest_files:
+            files_by_root[str(row["root_slug"])].append(row)
+
+        uploads_rows = files_by_root.get(SOURCE_ROOT_SLUG, [])
+        uploads_index = {str(row["relative_path"]) for row in uploads_rows}
+        source_only_rows = [row for row in uploads_rows if self._is_original_candidate(row)]
+        derivative_indexes = {
+            slug: {str(row["relative_path"]) for row in rows}
+            for slug, rows in files_by_root.items()
+            if slug in DERIVATIVE_ROOT_SLUGS or slug == SOURCE_ROOT_SLUG
+        }
+
+        if progress_callback is not None:
+            progress_callback(
+                {
+                    "phase": "catalog",
+                    "current": 1,
+                    "total": 4,
+                    "percent": 25.0,
+                    "message": "Loaded persisted catalog snapshots.",
+                    "filesIndexed": len(latest_files),
+                }
+            )
+
+        asset_rows = self.postgres.list_all_assets_for_catalog_consistency(dsn, timeout)
+        asset_file_rows = self.postgres.list_all_asset_files_for_catalog_consistency(dsn, timeout)
+
+        db_missing_rows: list[dict[str, object]] = []
+        storage_missing_rows: list[dict[str, object]] = []
+        orphan_rows: list[dict[str, object]] = []
+        unmapped_rows: list[dict[str, object]] = []
+        db_original_index: set[str] = set()
+        original_by_asset: dict[str, str] = {}
+        derivative_rows_by_asset: dict[str, list[dict[str, object]]] = defaultdict(list)
+
+        for row in asset_file_rows:
+            derivative_rows_by_asset[str(row["assetId"])].append(row)
+
+        for index, asset in enumerate(asset_rows, start=1):
+            asset_id = str(asset["id"])
+            original_path = truthy_path(asset.get("originalPath"))
+            if not original_path:
+                continue
+            asset_name = truthy_path(asset.get("originalFileName"))
+
+            resolved_original = resolver.resolve(original_path)
+            if resolved_original is None:
+                unmapped_rows.append(
+                    {
+                        "asset_id": asset_id,
+                        "asset_name": asset_name,
+                        "path_kind": "original",
+                        "database_path": original_path,
+                        "mapping_status": (
+                            "legacy_path_unmapped"
+                            if resolver.looks_like_legacy_immich_path(original_path)
+                            else "unrecognized_path"
+                        ),
+                    }
+                )
+                continue
+
+            if resolved_original.root_slug != SOURCE_ROOT_SLUG:
+                unmapped_rows.append(
+                    {
+                        "asset_id": asset_id,
+                        "asset_name": asset_name,
+                        "path_kind": "original",
+                        "database_path": original_path,
+                        "mapping_status": "unexpected_root",
+                        "resolved_root": resolved_original.root_slug,
+                        "mapping_mode": resolved_original.mapping_mode,
+                    }
+                )
+                continue
+
+            db_original_index.add(resolved_original.relative_path)
+            original_by_asset[asset_id] = resolved_original.relative_path
+            if resolved_original.relative_path not in uploads_index:
+                db_missing_rows.append(
+                    {
+                        "asset_id": asset_id,
+                        "asset_name": asset_name,
+                        "asset_type": asset.get("type"),
+                        "database_path": original_path,
+                        "resolved_root": resolved_original.root_slug,
+                        "relative_path": resolved_original.relative_path,
+                        "mapping_mode": resolved_original.mapping_mode,
+                    }
+                )
+
+            if progress_callback is not None and index % 2500 == 0:
+                progress_callback(
+                    {
+                        "phase": "database-originals",
+                        "current": index,
+                        "total": len(asset_rows),
+                        "percent": round(25 + (index / max(len(asset_rows), 1)) * 25, 2),
+                        "message": "Compared DB original paths against the cached uploads index.",
+                        "dbMissingCount": len(db_missing_rows),
+                        "unmappedCount": len(unmapped_rows),
+                    }
+                )
+
+        for row in source_only_rows:
+            relative_path = str(row["relative_path"])
+            if relative_path in db_original_index:
+                continue
+            storage_missing_rows.append(
+                {
+                    "root_slug": row["root_slug"],
+                    "relative_path": relative_path,
+                    "file_name": row["file_name"],
+                    "size_bytes": row["size_bytes"],
+                    "snapshot_id": row["snapshot_id"],
+                    "generation": row["generation"],
+                }
+            )
+
+        if progress_callback is not None:
+            progress_callback(
+                {
+                    "phase": "storage-originals",
+                    "current": len(source_only_rows),
+                    "total": len(source_only_rows),
+                    "percent": 75.0,
+                    "message": "Compared cached storage originals against DB original paths.",
+                    "storageMissingCount": len(storage_missing_rows),
+                }
+            )
+
+        orphan_keys: set[tuple[str, str, str]] = set()
+        for asset in asset_rows:
+            asset_id = str(asset["id"])
+            original_relative_path = original_by_asset.get(asset_id)
+            if original_relative_path is None or original_relative_path in uploads_index:
+                continue
+
+            encoded_video_path = truthy_path(asset.get("encodedVideoPath"))
+            if encoded_video_path:
+                self._append_orphan_row(
+                    orphan_rows,
+                    orphan_keys,
+                    asset_id=asset_id,
+                    derivative_type="encoded_video",
+                    resolver=resolver,
+                    path_text=encoded_video_path,
+                    derivative_indexes=derivative_indexes,
+                    original_relative_path=original_relative_path,
+                )
+
+            for derivative in derivative_rows_by_asset.get(asset_id, []):
+                self._append_orphan_row(
+                    orphan_rows,
+                    orphan_keys,
+                    asset_id=asset_id,
+                    derivative_type=str(derivative["type"]),
+                    resolver=resolver,
+                    path_text=str(derivative["path"]),
+                    derivative_indexes=derivative_indexes,
+                    original_relative_path=original_relative_path,
+                )
+
+        if progress_callback is not None:
+            progress_callback(
+                {
+                    "phase": "orphans",
+                    "current": len(orphan_rows),
+                    "total": len(orphan_rows),
+                    "percent": 100.0,
+                    "message": (
+                        "Derived orphan derivative findings from the cached catalog "
+                        "and DB graph."
+                    ),
+                    "orphanCount": len(orphan_rows),
+                }
+            )
+
+        derivative_snapshot_coverage = sorted(
+            slug
+            for slug in snapshot_state.snapshot_by_slug
+            if slug in DERIVATIVE_ROOT_SLUGS or slug == SOURCE_ROOT_SLUG
+        )
+        checks.append(
+            CheckResult(
+                name="catalog_snapshot_coverage",
+                status=CheckStatus.PASS if derivative_snapshot_coverage else CheckStatus.WARN,
+                message=(
+                    "Committed catalog snapshots are available for the required storage roots."
+                    if derivative_snapshot_coverage
+                    else "Only a partial set of catalog snapshots is available."
+                ),
+                details={"roots": derivative_snapshot_coverage},
+            )
+        )
+        checks.append(
+            CheckResult(
+                name="catalog_path_mapping",
+                status=CheckStatus.WARN if unmapped_rows else CheckStatus.PASS,
+                message=(
+                    f"{len(unmapped_rows)} database paths could not be mapped "
+                    "into configured runtime roots."
+                    if unmapped_rows
+                    else "Database paths mapped cleanly into configured runtime roots."
+                ),
+            )
+        )
+
+        snapshot_basis = [
+            {
+                "rootSlug": str(row["root_slug"]),
+                "snapshotId": row["snapshot_id"],
+                "generation": row["generation"],
+                "committedAt": row["committed_at"],
+                "absolutePath": row["absolute_path"],
+            }
+            for row in snapshot_state.latest_snapshots
+            if row.get("snapshot_id") is not None
+            and bool(row.get("snapshot_current"))
+            and str(row["root_slug"]) in snapshot_state.effective_root_slugs
+        ]
+        latest_scan_committed_at = max(
+            (
+                str(row["committed_at"])
+                for row in snapshot_state.latest_snapshots
+                if row.get("committed_at")
+                and bool(row.get("snapshot_current"))
+                and str(row["root_slug"]) in snapshot_state.effective_root_slugs
+            ),
+            default=None,
+        )
+
+        return CatalogConsistencyState(
+            checks=checks,
+            latest_snapshots=snapshot_state.latest_snapshots,
+            latest_files=latest_files,
+            asset_rows=asset_rows,
+            asset_file_rows=asset_file_rows,
+            zero_byte_rows=zero_byte_rows,
+            db_missing_rows=db_missing_rows,
+            storage_missing_rows=storage_missing_rows,
+            orphan_rows=orphan_rows,
+            unmapped_rows=unmapped_rows,
+            uploads_rows=uploads_rows,
+            uploads_index=uploads_index,
+            db_original_index=db_original_index,
+            original_by_asset=original_by_asset,
+            derivative_indexes=derivative_indexes,
+            snapshot_basis=snapshot_basis,
+            latest_scan_committed_at=latest_scan_committed_at,
+            configured_root_slugs=[row["slug"] for row in snapshot_state.synced_roots],
+            progress_metadata=snapshot_state.metadata,
+        )
+
+    def _is_original_candidate(self, row: dict[str, object]) -> bool:
+        extension = str(row.get("extension") or "").lower()
+        relative_path = str(row.get("relative_path") or "")
+        if extension == SIDECAR_EXTENSION:
+            return False
+        return not relative_path.endswith(SIDECAR_EXTENSION)
+
+    def _append_orphan_row(
+        self,
+        orphan_rows: list[dict[str, object]],
+        orphan_keys: set[tuple[str, str, str]],
+        *,
+        asset_id: str,
+        derivative_type: str,
+        resolver: ImmichStoragePathResolver,
+        path_text: str,
+        derivative_indexes: dict[str, set[str]],
+        original_relative_path: str,
+    ) -> None:
+        resolved = resolver.resolve(path_text)
+        if resolved is None:
+            return
+        if resolved.relative_path not in derivative_indexes.get(resolved.root_slug, set()):
+            return
+        key = (asset_id, derivative_type, resolved.relative_path)
+        if key in orphan_keys:
+            return
+        orphan_keys.add(key)
+        orphan_rows.append(
+            {
+                "asset_id": asset_id,
+                "derivative_type": derivative_type,
+                "root_slug": resolved.root_slug,
+                "relative_path": resolved.relative_path,
+                "database_path": path_text,
+                "original_relative_path": original_relative_path,
+            }
+        )

--- a/immich_doctor/catalog/remediation_models.py
+++ b/immich_doctor/catalog/remediation_models.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from immich_doctor.core.models import CheckResult, CheckStatus
+
+
+class CatalogRemediationFindingKind(StrEnum):
+    BROKEN_DB_ORIGINAL = "broken_db_original"
+    FUSE_HIDDEN_ORPHAN = "fuse_hidden_orphan"
+
+
+class BrokenDbOriginalClassification(StrEnum):
+    MISSING_CONFIRMED = "missing_confirmed"
+    FOUND_ELSEWHERE = "found_elsewhere"
+    UNRESOLVED_SEARCH_ERROR = "unresolved_search_error"
+
+
+class FuseHiddenOrphanClassification(StrEnum):
+    BLOCKED_IN_USE = "blocked_in_use"
+    DELETABLE_ORPHAN = "deletable_orphan"
+    CHECK_FAILED = "check_failed"
+
+
+class CatalogRemediationOperationStatus(StrEnum):
+    PLANNED = "planned"
+    APPLIED = "applied"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+    ALREADY_REMOVED = "already_removed"
+
+
+@dataclass(slots=True, frozen=True)
+class BrokenDbOriginalFinding:
+    finding_id: str
+    kind: CatalogRemediationFindingKind
+    asset_id: str
+    asset_name: str | None
+    asset_type: str | None
+    expected_database_path: str
+    expected_relative_path: str
+    classification: BrokenDbOriginalClassification
+    action_eligible: bool
+    action_reason: str
+    found_root_slug: str | None = None
+    found_relative_path: str | None = None
+    found_absolute_path: str | None = None
+    found_size_bytes: int | None = None
+    expected_size_bytes: int | None = None
+    search_error: str | None = None
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_id": self.finding_id,
+            "kind": self.kind.value,
+            "asset_id": self.asset_id,
+            "asset_name": self.asset_name,
+            "asset_type": self.asset_type,
+            "expected_database_path": self.expected_database_path,
+            "expected_relative_path": self.expected_relative_path,
+            "classification": self.classification.value,
+            "action_eligible": self.action_eligible,
+            "action_reason": self.action_reason,
+            "found_root_slug": self.found_root_slug,
+            "found_relative_path": self.found_relative_path,
+            "found_absolute_path": self.found_absolute_path,
+            "found_size_bytes": self.found_size_bytes,
+            "expected_size_bytes": self.expected_size_bytes,
+            "search_error": self.search_error,
+            "message": self.message,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class FuseHiddenOrphanFinding:
+    finding_id: str
+    kind: CatalogRemediationFindingKind
+    root_slug: str
+    relative_path: str
+    absolute_path: str
+    file_name: str
+    size_bytes: int
+    classification: FuseHiddenOrphanClassification
+    action_eligible: bool
+    action_reason: str
+    in_use_check_tool: str | None = None
+    in_use_check_reason: str | None = None
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_id": self.finding_id,
+            "kind": self.kind.value,
+            "root_slug": self.root_slug,
+            "relative_path": self.relative_path,
+            "absolute_path": self.absolute_path,
+            "file_name": self.file_name,
+            "size_bytes": self.size_bytes,
+            "classification": self.classification.value,
+            "action_eligible": self.action_eligible,
+            "action_reason": self.action_reason,
+            "in_use_check_tool": self.in_use_check_tool,
+            "in_use_check_reason": self.in_use_check_reason,
+            "message": self.message,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class CatalogRemediationOperationItem:
+    finding_id: str
+    kind: CatalogRemediationFindingKind
+    target_id: str
+    status: CatalogRemediationOperationStatus
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_id": self.finding_id,
+            "kind": self.kind.value,
+            "target_id": self.target_id,
+            "status": self.status.value,
+            "message": self.message,
+            "details": self.details,
+        }
+
+
+@dataclass(slots=True)
+class CatalogRemediationScanResult:
+    summary: str
+    checks: list[CheckResult]
+    broken_db_originals: list[BrokenDbOriginalFinding]
+    fuse_hidden_orphans: list[FuseHiddenOrphanFinding]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    recommendations: list[str] = field(default_factory=list)
+    generated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    @property
+    def overall_status(self) -> CheckStatus:
+        statuses = {check.status for check in self.checks}
+        if self.broken_db_originals or self.fuse_hidden_orphans:
+            statuses.add(CheckStatus.WARN)
+        if CheckStatus.FAIL in statuses:
+            return CheckStatus.FAIL
+        if CheckStatus.WARN in statuses:
+            return CheckStatus.WARN
+        if CheckStatus.PASS in statuses:
+            return CheckStatus.PASS
+        return CheckStatus.SKIP
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "domain": "consistency.catalog_remediation",
+            "action": "scan",
+            "status": self.overall_status.value.upper(),
+            "summary": self.summary,
+            "generated_at": self.generated_at,
+            "checks": [check.to_dict() for check in self.checks],
+            "broken_db_originals": [item.to_dict() for item in self.broken_db_originals],
+            "fuse_hidden_orphans": [item.to_dict() for item in self.fuse_hidden_orphans],
+            "metadata": self.metadata,
+            "recommendations": self.recommendations,
+        }
+
+
+@dataclass(slots=True)
+class CatalogRemediationPreviewResult:
+    summary: str
+    checks: list[CheckResult]
+    finding_kind: CatalogRemediationFindingKind
+    repair_run_id: str
+    selected_items: list[dict[str, Any]]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    recommendations: list[str] = field(default_factory=list)
+    generated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    @property
+    def overall_status(self) -> CheckStatus:
+        statuses = {check.status for check in self.checks}
+        if self.selected_items:
+            statuses.add(CheckStatus.WARN)
+        if CheckStatus.FAIL in statuses:
+            return CheckStatus.FAIL
+        if CheckStatus.WARN in statuses:
+            return CheckStatus.WARN
+        return CheckStatus.SKIP
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "domain": "consistency.catalog_remediation",
+            "action": "preview",
+            "status": self.overall_status.value.upper(),
+            "summary": self.summary,
+            "generated_at": self.generated_at,
+            "checks": [check.to_dict() for check in self.checks],
+            "finding_kind": self.finding_kind.value,
+            "repair_run_id": self.repair_run_id,
+            "selected_items": self.selected_items,
+            "metadata": self.metadata,
+            "recommendations": self.recommendations,
+        }
+
+
+@dataclass(slots=True)
+class CatalogRemediationApplyResult:
+    summary: str
+    checks: list[CheckResult]
+    finding_kind: CatalogRemediationFindingKind
+    repair_run_id: str
+    items: list[CatalogRemediationOperationItem]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    recommendations: list[str] = field(default_factory=list)
+    generated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    @property
+    def overall_status(self) -> CheckStatus:
+        statuses = {check.status for check in self.checks}
+        item_statuses = {item.status for item in self.items}
+        if CatalogRemediationOperationStatus.FAILED in item_statuses:
+            return CheckStatus.FAIL
+        if item_statuses.intersection(
+            {
+                CatalogRemediationOperationStatus.APPLIED,
+                CatalogRemediationOperationStatus.ALREADY_REMOVED,
+                CatalogRemediationOperationStatus.SKIPPED,
+            }
+        ):
+            return CheckStatus.PASS
+        if CheckStatus.FAIL in statuses:
+            return CheckStatus.FAIL
+        if CheckStatus.WARN in statuses:
+            return CheckStatus.WARN
+        return CheckStatus.SKIP
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "domain": "consistency.catalog_remediation",
+            "action": "apply",
+            "status": self.overall_status.value.upper(),
+            "summary": self.summary,
+            "generated_at": self.generated_at,
+            "checks": [check.to_dict() for check in self.checks],
+            "finding_kind": self.finding_kind.value,
+            "repair_run_id": self.repair_run_id,
+            "items": [item.to_dict() for item in self.items],
+            "metadata": self.metadata,
+            "recommendations": self.recommendations,
+        }

--- a/immich_doctor/catalog/remediation_models.py
+++ b/immich_doctor/catalog/remediation_models.py
@@ -10,13 +10,30 @@ from immich_doctor.core.models import CheckResult, CheckStatus
 
 class CatalogRemediationFindingKind(StrEnum):
     BROKEN_DB_ORIGINAL = "broken_db_original"
+    ZERO_BYTE_FILE = "zero_byte_file"
     FUSE_HIDDEN_ORPHAN = "fuse_hidden_orphan"
+
+
+class CatalogRemediationActionKind(StrEnum):
+    BROKEN_DB_CLEANUP = "broken_db_cleanup"
+    BROKEN_DB_PATH_FIX = "broken_db_path_fix"
+    ZERO_BYTE_DELETE = "zero_byte_delete"
+    FUSE_HIDDEN_DELETE = "fuse_hidden_delete"
 
 
 class BrokenDbOriginalClassification(StrEnum):
     MISSING_CONFIRMED = "missing_confirmed"
     FOUND_ELSEWHERE = "found_elsewhere"
+    FOUND_WITH_HASH_MATCH = "found_with_hash_match"
     UNRESOLVED_SEARCH_ERROR = "unresolved_search_error"
+
+
+class ZeroByteClassification(StrEnum):
+    ZERO_BYTE_UPLOAD_ORPHAN = "zero_byte_upload_orphan"
+    ZERO_BYTE_UPLOAD_CRITICAL = "zero_byte_upload_critical"
+    ZERO_BYTE_VIDEO_DERIVATIVE = "zero_byte_video_derivative"
+    ZERO_BYTE_THUMB_DERIVATIVE = "zero_byte_thumb_derivative"
+    IGNORE_INTERNAL = "ignore_internal"
 
 
 class FuseHiddenOrphanClassification(StrEnum):
@@ -40,18 +57,29 @@ class BrokenDbOriginalFinding:
     asset_id: str
     asset_name: str | None
     asset_type: str | None
+    classification: BrokenDbOriginalClassification
     expected_database_path: str
     expected_relative_path: str
-    classification: BrokenDbOriginalClassification
-    action_eligible: bool
+    expected_absolute_path: str | None
+    found_root_slug: str | None
+    found_relative_path: str | None
+    found_absolute_path: str | None
+    found_size_bytes: int | None
+    expected_size_bytes: int | None
+    checksum_value: str | None
+    checksum_algorithm: str | None
+    checksum_match: bool | None
+    eligible_actions: tuple[CatalogRemediationActionKind, ...]
     action_reason: str
-    found_root_slug: str | None = None
-    found_relative_path: str | None = None
-    found_absolute_path: str | None = None
-    found_size_bytes: int | None = None
-    expected_size_bytes: int | None = None
     search_error: str | None = None
     message: str = ""
+
+    @property
+    def action_eligible(self) -> bool:
+        return bool(self.eligible_actions)
+
+    def supports_action(self, action: CatalogRemediationActionKind) -> bool:
+        return action in self.eligible_actions
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -60,17 +88,66 @@ class BrokenDbOriginalFinding:
             "asset_id": self.asset_id,
             "asset_name": self.asset_name,
             "asset_type": self.asset_type,
+            "classification": self.classification.value,
             "expected_database_path": self.expected_database_path,
             "expected_relative_path": self.expected_relative_path,
-            "classification": self.classification.value,
-            "action_eligible": self.action_eligible,
-            "action_reason": self.action_reason,
+            "expected_absolute_path": self.expected_absolute_path,
             "found_root_slug": self.found_root_slug,
             "found_relative_path": self.found_relative_path,
             "found_absolute_path": self.found_absolute_path,
             "found_size_bytes": self.found_size_bytes,
             "expected_size_bytes": self.expected_size_bytes,
+            "checksum_value": self.checksum_value,
+            "checksum_algorithm": self.checksum_algorithm,
+            "checksum_match": self.checksum_match,
+            "eligible_actions": [action.value for action in self.eligible_actions],
+            "action_eligible": self.action_eligible,
+            "action_reason": self.action_reason,
             "search_error": self.search_error,
+            "message": self.message,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ZeroByteFinding:
+    finding_id: str
+    kind: CatalogRemediationFindingKind
+    root_slug: str
+    relative_path: str
+    absolute_path: str
+    file_name: str
+    size_bytes: int
+    classification: ZeroByteClassification
+    asset_id: str | None
+    asset_name: str | None
+    original_relative_path: str | None
+    eligible_actions: tuple[CatalogRemediationActionKind, ...]
+    action_reason: str
+    message: str = ""
+
+    @property
+    def action_eligible(self) -> bool:
+        return bool(self.eligible_actions)
+
+    def supports_action(self, action: CatalogRemediationActionKind) -> bool:
+        return action in self.eligible_actions
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_id": self.finding_id,
+            "kind": self.kind.value,
+            "root_slug": self.root_slug,
+            "relative_path": self.relative_path,
+            "absolute_path": self.absolute_path,
+            "file_name": self.file_name,
+            "size_bytes": self.size_bytes,
+            "classification": self.classification.value,
+            "asset_id": self.asset_id,
+            "asset_name": self.asset_name,
+            "original_relative_path": self.original_relative_path,
+            "eligible_actions": [action.value for action in self.eligible_actions],
+            "action_eligible": self.action_eligible,
+            "action_reason": self.action_reason,
             "message": self.message,
         }
 
@@ -85,11 +162,18 @@ class FuseHiddenOrphanFinding:
     file_name: str
     size_bytes: int
     classification: FuseHiddenOrphanClassification
-    action_eligible: bool
+    eligible_actions: tuple[CatalogRemediationActionKind, ...]
     action_reason: str
     in_use_check_tool: str | None = None
     in_use_check_reason: str | None = None
     message: str = ""
+
+    @property
+    def action_eligible(self) -> bool:
+        return bool(self.eligible_actions)
+
+    def supports_action(self, action: CatalogRemediationActionKind) -> bool:
+        return action in self.eligible_actions
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -101,6 +185,7 @@ class FuseHiddenOrphanFinding:
             "file_name": self.file_name,
             "size_bytes": self.size_bytes,
             "classification": self.classification.value,
+            "eligible_actions": [action.value for action in self.eligible_actions],
             "action_eligible": self.action_eligible,
             "action_reason": self.action_reason,
             "in_use_check_tool": self.in_use_check_tool,
@@ -113,6 +198,7 @@ class FuseHiddenOrphanFinding:
 class CatalogRemediationOperationItem:
     finding_id: str
     kind: CatalogRemediationFindingKind
+    action_kind: CatalogRemediationActionKind
     target_id: str
     status: CatalogRemediationOperationStatus
     message: str
@@ -122,6 +208,7 @@ class CatalogRemediationOperationItem:
         return {
             "finding_id": self.finding_id,
             "kind": self.kind.value,
+            "action_kind": self.action_kind.value,
             "target_id": self.target_id,
             "status": self.status.value,
             "message": self.message,
@@ -134,6 +221,7 @@ class CatalogRemediationScanResult:
     summary: str
     checks: list[CheckResult]
     broken_db_originals: list[BrokenDbOriginalFinding]
+    zero_byte_findings: list[ZeroByteFinding]
     fuse_hidden_orphans: list[FuseHiddenOrphanFinding]
     metadata: dict[str, Any] = field(default_factory=dict)
     recommendations: list[str] = field(default_factory=list)
@@ -142,7 +230,7 @@ class CatalogRemediationScanResult:
     @property
     def overall_status(self) -> CheckStatus:
         statuses = {check.status for check in self.checks}
-        if self.broken_db_originals or self.fuse_hidden_orphans:
+        if self.broken_db_originals or self.zero_byte_findings or self.fuse_hidden_orphans:
             statuses.add(CheckStatus.WARN)
         if CheckStatus.FAIL in statuses:
             return CheckStatus.FAIL
@@ -161,6 +249,7 @@ class CatalogRemediationScanResult:
             "generated_at": self.generated_at,
             "checks": [check.to_dict() for check in self.checks],
             "broken_db_originals": [item.to_dict() for item in self.broken_db_originals],
+            "zero_byte_findings": [item.to_dict() for item in self.zero_byte_findings],
             "fuse_hidden_orphans": [item.to_dict() for item in self.fuse_hidden_orphans],
             "metadata": self.metadata,
             "recommendations": self.recommendations,
@@ -172,6 +261,7 @@ class CatalogRemediationPreviewResult:
     summary: str
     checks: list[CheckResult]
     finding_kind: CatalogRemediationFindingKind
+    action_kind: CatalogRemediationActionKind
     repair_run_id: str
     selected_items: list[dict[str, Any]]
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -198,6 +288,7 @@ class CatalogRemediationPreviewResult:
             "generated_at": self.generated_at,
             "checks": [check.to_dict() for check in self.checks],
             "finding_kind": self.finding_kind.value,
+            "action_kind": self.action_kind.value,
             "repair_run_id": self.repair_run_id,
             "selected_items": self.selected_items,
             "metadata": self.metadata,
@@ -210,6 +301,7 @@ class CatalogRemediationApplyResult:
     summary: str
     checks: list[CheckResult]
     finding_kind: CatalogRemediationFindingKind
+    action_kind: CatalogRemediationActionKind
     repair_run_id: str
     items: list[CatalogRemediationOperationItem]
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -245,6 +337,7 @@ class CatalogRemediationApplyResult:
             "generated_at": self.generated_at,
             "checks": [check.to_dict() for check in self.checks],
             "finding_kind": self.finding_kind.value,
+            "action_kind": self.action_kind.value,
             "repair_run_id": self.repair_run_id,
             "items": [item.to_dict() for item in self.items],
             "metadata": self.metadata,

--- a/immich_doctor/catalog/remediation_service.py
+++ b/immich_doctor/catalog/remediation_service.py
@@ -9,11 +9,14 @@ from immich_doctor.adapters.filesystem import FilesystemAdapter
 from immich_doctor.adapters.postgres import PostgresAdapter
 from immich_doctor.catalog.consistency_state import (
     SOURCE_ROOT_SLUG,
+    CatalogConsistencyState,
     CatalogConsistencyStateCollector,
+    truthy_path,
 )
 from immich_doctor.catalog.remediation_models import (
     BrokenDbOriginalClassification,
     BrokenDbOriginalFinding,
+    CatalogRemediationActionKind,
     CatalogRemediationApplyResult,
     CatalogRemediationFindingKind,
     CatalogRemediationOperationItem,
@@ -22,6 +25,8 @@ from immich_doctor.catalog.remediation_models import (
     CatalogRemediationScanResult,
     FuseHiddenOrphanClassification,
     FuseHiddenOrphanFinding,
+    ZeroByteClassification,
+    ZeroByteFinding,
 )
 from immich_doctor.consistency.missing_asset_models import (
     MissingAssetOperationItem,
@@ -46,6 +51,16 @@ from immich_doctor.repair import (
     validate_plan_token,
 )
 from immich_doctor.repair.paths import repair_run_directory
+from immich_doctor.storage.path_mapping import ImmichStoragePathResolver
+
+
+@dataclass(slots=True, frozen=True)
+class _LocatedFile:
+    root_slug: str
+    relative_path: str
+    absolute_path: str
+    file_name: str
+    size_bytes: int
 
 
 @dataclass(slots=True)
@@ -55,7 +70,12 @@ class CatalogRemediationService:
     external_tools: ExternalToolsAdapter = field(default_factory=ExternalToolsAdapter)
     repair_store: RepairJournalStore = field(default_factory=RepairJournalStore)
 
-    def scan(self, settings: AppSettings) -> CatalogRemediationScanResult:
+    def scan(
+        self,
+        settings: AppSettings,
+        *,
+        classifications: tuple[str, ...] = (),
+    ) -> CatalogRemediationScanResult:
         snapshot_collector = CatalogConsistencyStateCollector(postgres=self.postgres)
         snapshot_state = snapshot_collector.prepare_snapshot_state(settings)
         if not snapshot_state.ready:
@@ -63,6 +83,7 @@ class CatalogRemediationService:
                 summary="Catalog remediation is waiting for a current committed storage index.",
                 checks=snapshot_state.checks,
                 broken_db_originals=[],
+                zero_byte_findings=[],
                 fuse_hidden_orphans=[],
                 metadata=snapshot_state.metadata,
                 recommendations=[
@@ -84,6 +105,7 @@ class CatalogRemediationService:
                     ),
                 ],
                 broken_db_originals=[],
+                zero_byte_findings=[],
                 fuse_hidden_orphans=[],
                 metadata={"latestSnapshots": snapshot_state.latest_snapshots},
             )
@@ -95,22 +117,25 @@ class CatalogRemediationService:
                 summary="Catalog remediation failed because PostgreSQL could not be reached.",
                 checks=[*snapshot_state.checks, connection_check],
                 broken_db_originals=[],
+                zero_byte_findings=[],
                 fuse_hidden_orphans=[],
                 metadata={"latestSnapshots": snapshot_state.latest_snapshots},
             )
 
         state = snapshot_collector.collect(settings)
         broken_db_originals = self._build_broken_db_original_findings(settings, state=state)
+        zero_byte_findings = self._build_zero_byte_findings(settings, state=state)
         fuse_hidden_orphans = self._build_fuse_hidden_findings(settings, state=state)
-        summary = (
-            "Catalog remediation classified "
-            f"{len(broken_db_originals)} broken DB originals and "
-            f"{len(fuse_hidden_orphans)} `.fuse_hidden*` orphan artifacts."
-        )
-        return CatalogRemediationScanResult(
-            summary=summary,
+        result = CatalogRemediationScanResult(
+            summary=(
+                "Catalog remediation classified "
+                f"{len(broken_db_originals)} broken DB originals, "
+                f"{len(zero_byte_findings)} zero-byte files, and "
+                f"{len(fuse_hidden_orphans)} `.fuse_hidden*` orphan artifacts."
+            ),
             checks=state.checks,
             broken_db_originals=broken_db_originals,
+            zero_byte_findings=zero_byte_findings,
             fuse_hidden_orphans=fuse_hidden_orphans,
             metadata={
                 "configuredRoots": state.configured_root_slugs,
@@ -119,22 +144,36 @@ class CatalogRemediationService:
                 "latestScanCommittedAt": state.latest_scan_committed_at,
                 "totals": {
                     "brokenDbOriginals": len(broken_db_originals),
-                    "brokenDbOriginalsEligible": sum(
-                        1 for item in broken_db_originals if item.action_eligible
+                    "brokenDbCleanupEligible": sum(
+                        1
+                        for item in broken_db_originals
+                        if item.supports_action(CatalogRemediationActionKind.BROKEN_DB_CLEANUP)
+                    ),
+                    "brokenDbPathFixEligible": sum(
+                        1
+                        for item in broken_db_originals
+                        if item.supports_action(CatalogRemediationActionKind.BROKEN_DB_PATH_FIX)
+                    ),
+                    "zeroByteFindings": len(zero_byte_findings),
+                    "zeroByteEligible": sum(
+                        1 for item in zero_byte_findings if item.action_eligible
                     ),
                     "fuseHiddenOrphans": len(fuse_hidden_orphans),
-                    "fuseHiddenOrphansEligible": sum(
+                    "fuseHiddenEligible": sum(
                         1 for item in fuse_hidden_orphans if item.action_eligible
                     ),
                 },
             },
             recommendations=[
-                "Review `found_elsewhere` rows manually before considering any path rebind flow.",
-                "Only `missing_confirmed` and `deletable_orphan` rows become eligible for apply.",
+                "Review `found_elsewhere` rows manually before any path-fix decision.",
+                "Only hash-verified path mismatches become eligible for explicit "
+                "DB path correction.",
+                "Zero-byte uploads referenced as originals remain inspect-only by default.",
             ],
         )
+        return self._filter_scan_result(result, classifications=classifications)
 
-    def preview_broken_db_originals(
+    def preview_broken_db_cleanup(
         self,
         settings: AppSettings,
         *,
@@ -146,14 +185,65 @@ class CatalogRemediationService:
             findings=scan_result.broken_db_originals,
             asset_ids=asset_ids,
             select_all=select_all,
+            action_kind=CatalogRemediationActionKind.BROKEN_DB_CLEANUP,
         )
         return self._preview_result(
             settings,
             scan_result=scan_result,
             finding_kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+            action_kind=CatalogRemediationActionKind.BROKEN_DB_CLEANUP,
             selected_items=[item.to_dict() for item in selected_findings],
             selected_ids=[item.asset_id for item in selected_findings],
             scope_key="asset_ids",
+            select_all=select_all,
+        )
+
+    def preview_broken_db_path_fix(
+        self,
+        settings: AppSettings,
+        *,
+        asset_ids: tuple[str, ...],
+        select_all: bool,
+    ) -> CatalogRemediationPreviewResult:
+        scan_result = self.scan(settings)
+        selected_findings = self._select_broken_db_originals(
+            findings=scan_result.broken_db_originals,
+            asset_ids=asset_ids,
+            select_all=select_all,
+            action_kind=CatalogRemediationActionKind.BROKEN_DB_PATH_FIX,
+        )
+        return self._preview_result(
+            settings,
+            scan_result=scan_result,
+            finding_kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+            action_kind=CatalogRemediationActionKind.BROKEN_DB_PATH_FIX,
+            selected_items=[item.to_dict() for item in selected_findings],
+            selected_ids=[item.asset_id for item in selected_findings],
+            scope_key="asset_ids",
+            select_all=select_all,
+        )
+
+    def preview_zero_byte_files(
+        self,
+        settings: AppSettings,
+        *,
+        finding_ids: tuple[str, ...],
+        select_all: bool,
+    ) -> CatalogRemediationPreviewResult:
+        scan_result = self.scan(settings)
+        selected_findings = self._select_zero_byte_findings(
+            findings=scan_result.zero_byte_findings,
+            finding_ids=finding_ids,
+            select_all=select_all,
+        )
+        return self._preview_result(
+            settings,
+            scan_result=scan_result,
+            finding_kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+            action_kind=CatalogRemediationActionKind.ZERO_BYTE_DELETE,
+            selected_items=[item.to_dict() for item in selected_findings],
+            selected_ids=[item.finding_id for item in selected_findings],
+            scope_key="finding_ids",
             select_all=select_all,
         )
 
@@ -174,6 +264,7 @@ class CatalogRemediationService:
             settings,
             scan_result=scan_result,
             finding_kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+            action_kind=CatalogRemediationActionKind.FUSE_HIDDEN_DELETE,
             selected_items=[item.to_dict() for item in selected_findings],
             selected_ids=[item.finding_id for item in selected_findings],
             scope_key="finding_ids",
@@ -184,6 +275,7 @@ class CatalogRemediationService:
         run = self.repair_store.load_run(settings, repair_run_id)
         plan_token = self.repair_store.load_plan_token(settings, repair_run_id)
         finding_kind = CatalogRemediationFindingKind(str(run.scope["finding_kind"]))
+        action_kind = CatalogRemediationActionKind(str(run.scope["action_kind"]))
         scan_result = self.scan(settings)
 
         if finding_kind == CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL:
@@ -191,9 +283,18 @@ class CatalogRemediationService:
                 findings=scan_result.broken_db_originals,
                 asset_ids=tuple(str(item) for item in run.scope.get("asset_ids", [])),
                 select_all=bool(run.scope.get("select_all", False)),
+                action_kind=action_kind,
             )
             current_scope_ids = [item.asset_id for item in selected_findings]
             scope_key = "asset_ids"
+        elif finding_kind == CatalogRemediationFindingKind.ZERO_BYTE_FILE:
+            selected_findings = self._select_zero_byte_findings(
+                findings=scan_result.zero_byte_findings,
+                finding_ids=tuple(str(item) for item in run.scope.get("finding_ids", [])),
+                select_all=bool(run.scope.get("select_all", False)),
+            )
+            current_scope_ids = [item.finding_id for item in selected_findings]
+            scope_key = "finding_ids"
         else:
             selected_findings = self._select_fuse_hidden_orphans(
                 findings=scan_result.fuse_hidden_orphans,
@@ -231,6 +332,7 @@ class CatalogRemediationService:
                 summary="Apply stopped because the preview scope drifted before mutation.",
                 checks=[*scan_result.checks, guard_check],
                 finding_kind=finding_kind,
+                action_kind=action_kind,
                 repair_run_id=repair_run_id,
                 items=[],
                 metadata={"environment": settings.environment, "dry_run": False},
@@ -241,8 +343,20 @@ class CatalogRemediationService:
 
         run.status = RepairRunStatus.RUNNING
         self.repair_store.update_run(settings, run)
-        if finding_kind == CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL:
-            items = self._apply_broken_db_originals(
+        if action_kind == CatalogRemediationActionKind.BROKEN_DB_CLEANUP:
+            items = self._apply_broken_db_cleanup(
+                settings,
+                repair_run=run,
+                findings=selected_findings,
+            )
+        elif action_kind == CatalogRemediationActionKind.BROKEN_DB_PATH_FIX:
+            items = self._apply_broken_db_path_fix(
+                settings,
+                repair_run=run,
+                findings=selected_findings,
+            )
+        elif action_kind == CatalogRemediationActionKind.ZERO_BYTE_DELETE:
+            items = self._apply_zero_byte_findings(
                 settings,
                 repair_run=run,
                 findings=selected_findings,
@@ -259,6 +373,7 @@ class CatalogRemediationService:
             summary=f"Apply processed {len(items)} selected remediation items.",
             checks=[*scan_result.checks, guard_check, self._journal_check(settings, run)],
             finding_kind=finding_kind,
+            action_kind=action_kind,
             repair_run_id=repair_run_id,
             items=items,
             metadata={"environment": settings.environment, "dry_run": False},
@@ -268,12 +383,38 @@ class CatalogRemediationService:
             ],
         )
 
+    def _filter_scan_result(
+        self,
+        result: CatalogRemediationScanResult,
+        *,
+        classifications: tuple[str, ...],
+    ) -> CatalogRemediationScanResult:
+        if not classifications:
+            return result
+        allowed = {item.strip() for item in classifications if item.strip()}
+        return CatalogRemediationScanResult(
+            summary=result.summary,
+            checks=result.checks,
+            broken_db_originals=[
+                item for item in result.broken_db_originals if item.classification.value in allowed
+            ],
+            zero_byte_findings=[
+                item for item in result.zero_byte_findings if item.classification.value in allowed
+            ],
+            fuse_hidden_orphans=[
+                item for item in result.fuse_hidden_orphans if item.classification.value in allowed
+            ],
+            metadata={**result.metadata, "classificationFilter": sorted(allowed)},
+            recommendations=result.recommendations,
+        )
+
     def _preview_result(
         self,
         settings: AppSettings,
         *,
         scan_result: CatalogRemediationScanResult,
         finding_kind: CatalogRemediationFindingKind,
+        action_kind: CatalogRemediationActionKind,
         selected_items: list[dict[str, object]],
         selected_ids: list[str],
         scope_key: str,
@@ -283,6 +424,7 @@ class CatalogRemediationService:
             "domain": "consistency.catalog_remediation",
             "action": "preview",
             "finding_kind": finding_kind.value,
+            "action_kind": action_kind.value,
             scope_key: selected_ids,
             "select_all": select_all,
         }
@@ -316,6 +458,7 @@ class CatalogRemediationService:
                     "select_all": select_all,
                     "repair_run_id": repair_run.repair_run_id,
                     "finding_kind": finding_kind.value,
+                    "action_kind": action_kind.value,
                 },
             )
         )
@@ -337,6 +480,7 @@ class CatalogRemediationService:
             summary=f"Preview planned {len(selected_items)} remediation items.",
             checks=checks,
             finding_kind=finding_kind,
+            action_kind=action_kind,
             repair_run_id=repair_run.repair_run_id,
             selected_items=selected_items,
             metadata={"environment": settings.environment, "dry_run": True},
@@ -350,8 +494,17 @@ class CatalogRemediationService:
         self,
         settings: AppSettings,
         *,
-        state,
+        state: CatalogConsistencyState,
     ) -> list[BrokenDbOriginalFinding]:
+        resolver = ImmichStoragePathResolver(settings)
+        uploads_root = settings.immich_uploads_path
+        if uploads_root is None:
+            return []
+        uploads_files_by_relative = {
+            str(row["relative_path"]): row
+            for row in state.latest_files
+            if str(row.get("root_slug")) == SOURCE_ROOT_SLUG
+        }
         files_by_name: dict[str, list[dict[str, object]]] = {}
         for row in state.latest_files:
             file_name = str(row.get("file_name") or "")
@@ -359,82 +512,116 @@ class CatalogRemediationService:
                 files_by_name.setdefault(file_name, []).append(row)
 
         findings: list[BrokenDbOriginalFinding] = []
-        uploads_root = settings.immich_uploads_path
-        for row in state.db_missing_rows:
-            asset_name = str(row.get("asset_name") or "").strip() or None
-            try:
-                matches = files_by_name.get(asset_name or "", [])
-                relocated_match = next(
-                    (
-                        item
-                        for item in matches
-                        if str(item["root_slug"]) == SOURCE_ROOT_SLUG
-                        and str(item["relative_path"]) != str(row["relative_path"])
-                    ),
-                    None,
+        handled_assets: set[str] = set()
+        for asset in state.asset_rows:
+            asset_id = str(asset["id"])
+            original_path = truthy_path(asset.get("originalPath"))
+            if original_path is None:
+                continue
+            resolved_original = resolver.resolve(original_path)
+            if resolved_original is None or resolved_original.root_slug != SOURCE_ROOT_SLUG:
+                continue
+            normalized_db_path = self._normalize_path_text(original_path)
+            normalized_canonical_path = self._normalize_path_text(
+                str(resolved_original.absolute_path)
+            )
+            canonical_row = uploads_files_by_relative.get(resolved_original.relative_path)
+            if canonical_row is not None and normalized_db_path != normalized_canonical_path:
+                findings.append(
+                    self._build_located_broken_db_finding(
+                        asset=asset,
+                        expected_relative_path=resolved_original.relative_path,
+                        expected_database_path=original_path,
+                        expected_absolute_path=str(resolved_original.absolute_path),
+                        located_file=_LocatedFile(
+                            root_slug=SOURCE_ROOT_SLUG,
+                            relative_path=resolved_original.relative_path,
+                            absolute_path=str(resolved_original.absolute_path),
+                            file_name=str(canonical_row["file_name"]),
+                            size_bytes=int(canonical_row["size_bytes"]),
+                        ),
+                    )
                 )
-                if relocated_match is not None and uploads_root is not None:
-                    found_relative_path = str(relocated_match["relative_path"])
+                handled_assets.add(asset_id)
+
+        for row in state.db_missing_rows:
+            asset_id = str(row["asset_id"])
+            if asset_id in handled_assets:
+                continue
+            asset = next((item for item in state.asset_rows if str(item["id"]) == asset_id), None)
+            if asset is None:
+                continue
+            asset_name = str(asset.get("originalFileName") or "").strip()
+            try:
+                located = self._search_for_relocated_file(
+                    settings=settings,
+                    files_by_name=files_by_name,
+                    asset_name=asset_name,
+                    expected_relative_path=str(row["relative_path"]),
+                )
+                if located is None:
                     findings.append(
                         BrokenDbOriginalFinding(
-                            finding_id=f"broken-db-original:{row['asset_id']}",
+                            finding_id=f"broken-db-original:{asset_id}",
                             kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
-                            asset_id=str(row["asset_id"]),
-                            asset_name=asset_name,
-                            asset_type=str(row.get("asset_type") or "") or None,
+                            asset_id=asset_id,
+                            asset_name=asset_name or None,
+                            asset_type=str(asset.get("type") or "") or None,
+                            classification=BrokenDbOriginalClassification.MISSING_CONFIRMED,
                             expected_database_path=str(row["database_path"]),
                             expected_relative_path=str(row["relative_path"]),
-                            classification=BrokenDbOriginalClassification.FOUND_ELSEWHERE,
-                            action_eligible=False,
-                            action_reason=(
-                                "A file with the same name exists elsewhere in storage. "
-                                "This row is inspect-only by default."
-                            ),
-                            found_root_slug=str(relocated_match["root_slug"]),
-                            found_relative_path=found_relative_path,
-                            found_absolute_path=str(uploads_root / found_relative_path),
-                            found_size_bytes=int(relocated_match["size_bytes"]),
+                            expected_absolute_path=str(uploads_root / str(row["relative_path"])),
+                            found_root_slug=None,
+                            found_relative_path=None,
+                            found_absolute_path=None,
+                            found_size_bytes=None,
                             expected_size_bytes=None,
+                            checksum_value=self._asset_checksum_value(asset),
+                            checksum_algorithm=self._asset_checksum_algorithm(asset),
+                            checksum_match=None,
+                            eligible_actions=(CatalogRemediationActionKind.BROKEN_DB_CLEANUP,),
+                            action_reason=(
+                                "The expected storage path is absent and no "
+                                "candidate file was found "
+                                "in the current cached storage inventory."
+                            ),
                             message=(
-                                "Expected storage path is missing, but a same-name file was found "
-                                "elsewhere in the cached storage inventory."
+                                "Expected storage path is missing and the cached storage inventory "
+                                "found no relocation candidate."
                             ),
                         )
                     )
                     continue
                 findings.append(
-                    BrokenDbOriginalFinding(
-                        finding_id=f"broken-db-original:{row['asset_id']}",
-                        kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
-                        asset_id=str(row["asset_id"]),
-                        asset_name=asset_name,
-                        asset_type=str(row.get("asset_type") or "") or None,
-                        expected_database_path=str(row["database_path"]),
+                    self._build_located_broken_db_finding(
+                        asset=asset,
                         expected_relative_path=str(row["relative_path"]),
-                        classification=BrokenDbOriginalClassification.MISSING_CONFIRMED,
-                        action_eligible=True,
-                        action_reason=(
-                            "The expected storage path is absent and no same-name relocation was "
-                            "found in the current cached storage inventory."
-                        ),
-                        message=(
-                            "Expected storage path is missing and the cached storage inventory "
-                            "found no same-name relocation."
-                        ),
+                        expected_database_path=str(row["database_path"]),
+                        expected_absolute_path=str(uploads_root / str(row["relative_path"])),
+                        located_file=located,
                     )
                 )
             except Exception as exc:
                 findings.append(
                     BrokenDbOriginalFinding(
-                        finding_id=f"broken-db-original:{row['asset_id']}",
+                        finding_id=f"broken-db-original:{asset_id}",
                         kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
-                        asset_id=str(row["asset_id"]),
-                        asset_name=asset_name,
-                        asset_type=str(row.get("asset_type") or "") or None,
+                        asset_id=asset_id,
+                        asset_name=asset_name or None,
+                        asset_type=str(asset.get("type") or "") or None,
+                        classification=BrokenDbOriginalClassification.UNRESOLVED_SEARCH_ERROR,
                         expected_database_path=str(row["database_path"]),
                         expected_relative_path=str(row["relative_path"]),
-                        classification=BrokenDbOriginalClassification.UNRESOLVED_SEARCH_ERROR,
-                        action_eligible=False,
+                        expected_absolute_path=str(uploads_root / str(row["relative_path"])),
+                        found_root_slug=None,
+                        found_relative_path=None,
+                        found_absolute_path=None,
+                        found_size_bytes=None,
+                        expected_size_bytes=None,
+                        checksum_value=self._asset_checksum_value(asset),
+                        checksum_algorithm=self._asset_checksum_algorithm(asset),
+                        checksum_match=None,
+                        eligible_actions=(),
                         action_reason="Relocation search did not complete safely.",
                         search_error=str(exc),
                         message="Relocation search failed and the row remains inspect-only.",
@@ -442,22 +629,234 @@ class CatalogRemediationService:
                 )
         return findings
 
+    def _build_located_broken_db_finding(
+        self,
+        *,
+        asset: dict[str, object],
+        expected_relative_path: str,
+        expected_database_path: str,
+        expected_absolute_path: str,
+        located_file: _LocatedFile,
+    ) -> BrokenDbOriginalFinding:
+        checksum_value = self._asset_checksum_value(asset)
+        checksum_algorithm = self._asset_checksum_algorithm(asset)
+        checksum_match = None
+        if checksum_value and checksum_algorithm:
+            checksum_match = self._verify_file_checksum(
+                path=Path(located_file.absolute_path),
+                checksum_value=checksum_value,
+                checksum_algorithm=checksum_algorithm,
+            )
+        classification = BrokenDbOriginalClassification.FOUND_ELSEWHERE
+        eligible_actions: tuple[CatalogRemediationActionKind, ...] = ()
+        action_reason = (
+            "A candidate file was found elsewhere in storage. "
+            "This row remains inspect-only by default."
+        )
+        message = (
+            "Expected storage path is missing, but a candidate file was found "
+            "elsewhere in the cached storage inventory."
+        )
+        if checksum_match is True and located_file.root_slug == SOURCE_ROOT_SLUG:
+            classification = BrokenDbOriginalClassification.FOUND_WITH_HASH_MATCH
+            eligible_actions = (CatalogRemediationActionKind.BROKEN_DB_PATH_FIX,)
+            action_reason = (
+                "The candidate file matches the DB checksum and can be used "
+                "for an explicit DB path fix."
+            )
+            message = (
+                "A relocated file was found and its checksum matches the DB checksum. "
+                "This row is eligible for explicit path correction."
+            )
+        elif checksum_match is False:
+            action_reason = (
+                "A candidate file was found, but its checksum does not match the DB checksum."
+            )
+        elif checksum_value and checksum_algorithm is None:
+            action_reason = (
+                "A candidate file was found, but the DB checksum format is "
+                "not supported for auto-verification."
+            )
+        return BrokenDbOriginalFinding(
+            finding_id=f"broken-db-original:{asset['id']}",
+            kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+            asset_id=str(asset["id"]),
+            asset_name=truthy_path(asset.get("originalFileName")),
+            asset_type=truthy_path(asset.get("type")),
+            classification=classification,
+            expected_database_path=expected_database_path,
+            expected_relative_path=expected_relative_path,
+            expected_absolute_path=expected_absolute_path,
+            found_root_slug=located_file.root_slug,
+            found_relative_path=located_file.relative_path,
+            found_absolute_path=located_file.absolute_path,
+            found_size_bytes=located_file.size_bytes,
+            expected_size_bytes=None,
+            checksum_value=checksum_value,
+            checksum_algorithm=checksum_algorithm,
+            checksum_match=checksum_match,
+            eligible_actions=eligible_actions,
+            action_reason=action_reason,
+            message=message,
+        )
+
+    def _build_zero_byte_findings(
+        self,
+        settings: AppSettings,
+        *,
+        state: CatalogConsistencyState,
+    ) -> list[ZeroByteFinding]:
+        asset_by_id = {str(asset["id"]): asset for asset in state.asset_rows}
+        original_asset_by_relative = {
+            relative_path: asset_id for asset_id, relative_path in state.original_by_asset.items()
+        }
+        derivative_asset_by_key = self._build_derivative_asset_index(settings, state=state)
+        findings: list[ZeroByteFinding] = []
+        for row in state.zero_byte_rows:
+            root_slug = str(row["root_slug"])
+            relative_path = str(row["relative_path"])
+            file_name = str(row["file_name"])
+            if file_name == ".immich" or file_name.startswith(".fuse_hidden"):
+                continue
+            absolute_path = self._absolute_path_for(
+                settings,
+                root_slug=root_slug,
+                relative_path=relative_path,
+            )
+            if absolute_path is None:
+                continue
+
+            if root_slug == SOURCE_ROOT_SLUG:
+                asset_id = original_asset_by_relative.get(relative_path)
+                asset = asset_by_id.get(asset_id) if asset_id is not None else None
+                if asset is not None:
+                    findings.append(
+                        ZeroByteFinding(
+                            finding_id=f"zero-byte:{root_slug}:{relative_path}",
+                            kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+                            root_slug=root_slug,
+                            relative_path=relative_path,
+                            absolute_path=str(absolute_path),
+                            file_name=file_name,
+                            size_bytes=int(row["size_bytes"]),
+                            classification=ZeroByteClassification.ZERO_BYTE_UPLOAD_CRITICAL,
+                            asset_id=asset_id,
+                            asset_name=truthy_path(asset.get("originalFileName")),
+                            original_relative_path=relative_path,
+                            eligible_actions=(),
+                            action_reason=(
+                                "The zero-byte upload is referenced by the DB "
+                                "as the original file."
+                            ),
+                            message=(
+                                "The original upload is zero bytes and must "
+                                "not be auto-deleted."
+                            ),
+                        )
+                    )
+                    continue
+                findings.append(
+                    ZeroByteFinding(
+                        finding_id=f"zero-byte:{root_slug}:{relative_path}",
+                        kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+                        root_slug=root_slug,
+                        relative_path=relative_path,
+                        absolute_path=str(absolute_path),
+                        file_name=file_name,
+                        size_bytes=int(row["size_bytes"]),
+                        classification=ZeroByteClassification.ZERO_BYTE_UPLOAD_ORPHAN,
+                        asset_id=None,
+                        asset_name=None,
+                        original_relative_path=None,
+                        eligible_actions=(CatalogRemediationActionKind.ZERO_BYTE_DELETE,),
+                        action_reason="The zero-byte upload has no DB original reference.",
+                        message=(
+                            "The zero-byte upload is an orphan storage artifact "
+                            "and can be deleted."
+                        ),
+                    )
+                )
+                continue
+
+            if root_slug not in {"thumbs", "video"}:
+                continue
+
+            asset_id = derivative_asset_by_key.get((root_slug, relative_path))
+            asset = asset_by_id.get(asset_id) if asset_id is not None else None
+            if asset is None:
+                continue
+            original_relative_path = state.original_by_asset.get(asset_id)
+            if original_relative_path is None or original_relative_path not in state.uploads_index:
+                continue
+            findings.append(
+                ZeroByteFinding(
+                    finding_id=f"zero-byte:{root_slug}:{relative_path}",
+                    kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+                    root_slug=root_slug,
+                    relative_path=relative_path,
+                    absolute_path=str(absolute_path),
+                    file_name=file_name,
+                    size_bytes=int(row["size_bytes"]),
+                    classification=(
+                        ZeroByteClassification.ZERO_BYTE_VIDEO_DERIVATIVE
+                        if root_slug == "video"
+                        else ZeroByteClassification.ZERO_BYTE_THUMB_DERIVATIVE
+                    ),
+                    asset_id=asset_id,
+                    asset_name=truthy_path(asset.get("originalFileName")),
+                    original_relative_path=original_relative_path,
+                    eligible_actions=(CatalogRemediationActionKind.ZERO_BYTE_DELETE,),
+                    action_reason=(
+                        "The zero-byte derivative is linked to an asset whose "
+                        "original upload still exists."
+                    ),
+                    message=(
+                        "The derivative is zero bytes and can be deleted so "
+                        "it may be regenerated later."
+                    ),
+                )
+            )
+        return findings
+
+    def _build_derivative_asset_index(
+        self,
+        settings: AppSettings,
+        *,
+        state: CatalogConsistencyState,
+    ) -> dict[tuple[str, str], str]:
+        resolver = ImmichStoragePathResolver(settings)
+        index: dict[tuple[str, str], str] = {}
+        for asset in state.asset_rows:
+            asset_id = str(asset["id"])
+            encoded_video_path = truthy_path(asset.get("encodedVideoPath"))
+            if encoded_video_path:
+                resolved_video = resolver.resolve(encoded_video_path)
+                if resolved_video is not None:
+                    index[(resolved_video.root_slug, resolved_video.relative_path)] = asset_id
+        for derivative in state.asset_file_rows:
+            asset_id = str(derivative["assetId"])
+            path_text = truthy_path(derivative.get("path"))
+            if path_text is None:
+                continue
+            resolved = resolver.resolve(path_text)
+            if resolved is None:
+                continue
+            index[(resolved.root_slug, resolved.relative_path)] = asset_id
+        return index
+
     def _build_fuse_hidden_findings(
         self,
         settings: AppSettings,
         *,
-        state,
+        state: CatalogConsistencyState,
     ) -> list[FuseHiddenOrphanFinding]:
         uploads_root = settings.immich_uploads_path
         if uploads_root is None:
             return []
-
         findings: list[FuseHiddenOrphanFinding] = []
         for row in state.storage_missing_rows:
             file_name = str(row["file_name"])
-            if file_name == ".immich":
-                continue
-            if not file_name.startswith(".fuse_hidden"):
+            if file_name == ".immich" or not file_name.startswith(".fuse_hidden"):
                 continue
             absolute_path = uploads_root / str(row["relative_path"])
             inspection = self.external_tools.inspect_open_file_handles(absolute_path)
@@ -475,7 +874,7 @@ class CatalogRemediationService:
                         file_name=file_name,
                         size_bytes=int(row["size_bytes"]),
                         classification=FuseHiddenOrphanClassification.BLOCKED_IN_USE,
-                        action_eligible=False,
+                        eligible_actions=(),
                         action_reason="The orphan artifact is still held open by a process.",
                         in_use_check_tool=tool,
                         in_use_check_reason=reason,
@@ -494,7 +893,7 @@ class CatalogRemediationService:
                         file_name=file_name,
                         size_bytes=int(row["size_bytes"]),
                         classification=FuseHiddenOrphanClassification.DELETABLE_ORPHAN,
-                        action_eligible=True,
+                        eligible_actions=(CatalogRemediationActionKind.FUSE_HIDDEN_DELETE,),
                         action_reason="The orphan artifact is not reported as in use.",
                         in_use_check_tool=tool,
                         in_use_check_reason=reason,
@@ -515,7 +914,7 @@ class CatalogRemediationService:
                     file_name=file_name,
                     size_bytes=int(row["size_bytes"]),
                     classification=FuseHiddenOrphanClassification.CHECK_FAILED,
-                    action_eligible=False,
+                    eligible_actions=(),
                     action_reason="The in-use check was unavailable or failed.",
                     in_use_check_tool=tool,
                     in_use_check_reason=reason,
@@ -524,18 +923,67 @@ class CatalogRemediationService:
             )
         return findings
 
+    def _search_for_relocated_file(
+        self,
+        *,
+        settings: AppSettings,
+        files_by_name: dict[str, list[dict[str, object]]],
+        asset_name: str,
+        expected_relative_path: str,
+    ) -> _LocatedFile | None:
+        if not asset_name:
+            return None
+        matches = files_by_name.get(asset_name, [])
+        for item in matches:
+            relative_path = str(item["relative_path"])
+            root_slug = str(item["root_slug"])
+            if root_slug == SOURCE_ROOT_SLUG and relative_path == expected_relative_path:
+                continue
+            return _LocatedFile(
+                root_slug=root_slug,
+                relative_path=relative_path,
+                absolute_path=str(
+                    self._absolute_path_for(
+                        settings,
+                        root_slug=root_slug,
+                        relative_path=relative_path,
+                    )
+                    or Path(root_slug) / relative_path
+                ),
+                file_name=str(item["file_name"]),
+                size_bytes=int(item["size_bytes"]),
+            )
+        return None
+
     def _select_broken_db_originals(
         self,
         *,
         findings: list[BrokenDbOriginalFinding],
         asset_ids: tuple[str, ...],
         select_all: bool,
+        action_kind: CatalogRemediationActionKind,
     ) -> list[BrokenDbOriginalFinding]:
         selected_ids = set(asset_ids)
         return [
             finding
             for finding in findings
-            if finding.action_eligible and (select_all or finding.asset_id in selected_ids)
+            if finding.supports_action(action_kind)
+            and (select_all or finding.asset_id in selected_ids)
+        ]
+
+    def _select_zero_byte_findings(
+        self,
+        *,
+        findings: list[ZeroByteFinding],
+        finding_ids: tuple[str, ...],
+        select_all: bool,
+    ) -> list[ZeroByteFinding]:
+        selected_ids = set(finding_ids)
+        return [
+            finding
+            for finding in findings
+            if finding.supports_action(CatalogRemediationActionKind.ZERO_BYTE_DELETE)
+            and (select_all or finding.finding_id in selected_ids)
         ]
 
     def _select_fuse_hidden_orphans(
@@ -549,10 +997,11 @@ class CatalogRemediationService:
         return [
             finding
             for finding in findings
-            if finding.action_eligible and (select_all or finding.finding_id in selected_ids)
+            if finding.supports_action(CatalogRemediationActionKind.FUSE_HIDDEN_DELETE)
+            and (select_all or finding.finding_id in selected_ids)
         ]
 
-    def _apply_broken_db_originals(
+    def _apply_broken_db_cleanup(
         self,
         settings: AppSettings,
         *,
@@ -598,7 +1047,153 @@ class CatalogRemediationService:
                 repair_run=repair_run,
                 relations=profile.relations,
             )
-            items.append(self._map_missing_asset_operation(finding.finding_id, result))
+            items.append(
+                self._map_missing_asset_operation(
+                    finding.finding_id,
+                    result,
+                    action_kind=CatalogRemediationActionKind.BROKEN_DB_CLEANUP,
+                )
+            )
+        return items
+
+    def _apply_broken_db_path_fix(
+        self,
+        settings: AppSettings,
+        *,
+        repair_run: RepairRun,
+        findings: list[BrokenDbOriginalFinding],
+    ) -> list[CatalogRemediationOperationItem]:
+        dsn = settings.postgres_dsn_value()
+        if dsn is None:
+            return []
+        timeout = settings.postgres_connect_timeout_seconds
+        items: list[CatalogRemediationOperationItem] = []
+        for finding in findings:
+            target_path = truthy_path(finding.found_absolute_path)
+            if target_path is None:
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+                        action_kind=CatalogRemediationActionKind.BROKEN_DB_PATH_FIX,
+                        target_id=finding.asset_id,
+                        status=CatalogRemediationOperationStatus.SKIPPED,
+                        message="No target path is available for DB path correction.",
+                    )
+                )
+                continue
+            try:
+                update_row = self.postgres.update_asset_original_path(
+                    dsn,
+                    timeout,
+                    asset_id=finding.asset_id,
+                    new_original_path=target_path,
+                )
+                self._record_db_path_fix_journal(
+                    settings,
+                    repair_run=repair_run,
+                    finding=finding,
+                    old_original_path=str(update_row["oldOriginalPath"]),
+                    new_original_path=str(update_row["newOriginalPath"]),
+                )
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+                        action_kind=CatalogRemediationActionKind.BROKEN_DB_PATH_FIX,
+                        target_id=finding.asset_id,
+                        status=CatalogRemediationOperationStatus.APPLIED,
+                        message="Asset originalPath was updated to the verified storage path.",
+                        details={
+                            "oldOriginalPath": update_row["oldOriginalPath"],
+                            "newOriginalPath": update_row["newOriginalPath"],
+                        },
+                    )
+                )
+            except Exception as exc:
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+                        action_kind=CatalogRemediationActionKind.BROKEN_DB_PATH_FIX,
+                        target_id=finding.asset_id,
+                        status=CatalogRemediationOperationStatus.FAILED,
+                        message=f"DB path correction failed: {exc}",
+                    )
+                )
+        return items
+
+    def _apply_zero_byte_findings(
+        self,
+        settings: AppSettings,
+        *,
+        repair_run: RepairRun,
+        findings: list[ZeroByteFinding],
+    ) -> list[CatalogRemediationOperationItem]:
+        items: list[CatalogRemediationOperationItem] = []
+        for finding in findings:
+            target_path = Path(finding.absolute_path)
+            root_path = self._root_path_for(settings, root_slug=finding.root_slug)
+            if root_path is None or not self.filesystem.is_child_path(root_path, target_path):
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+                        action_kind=CatalogRemediationActionKind.ZERO_BYTE_DELETE,
+                        target_id=finding.relative_path,
+                        status=CatalogRemediationOperationStatus.SKIPPED,
+                        message=(
+                            "Target path is outside the configured storage root "
+                            "and was not touched."
+                        ),
+                    )
+                )
+                continue
+            if not self.filesystem.path_exists(target_path):
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+                        action_kind=CatalogRemediationActionKind.ZERO_BYTE_DELETE,
+                        target_id=finding.relative_path,
+                        status=CatalogRemediationOperationStatus.ALREADY_REMOVED,
+                        message="Zero-byte file is already absent from storage.",
+                    )
+                )
+                continue
+            try:
+                self.filesystem.delete_file(target_path)
+                self._record_storage_delete_journal(
+                    settings,
+                    repair_run=repair_run,
+                    finding_kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+                    action_kind=CatalogRemediationActionKind.ZERO_BYTE_DELETE,
+                    target_id=finding.relative_path,
+                    absolute_path=finding.absolute_path,
+                    classification=finding.classification.value,
+                )
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+                        action_kind=CatalogRemediationActionKind.ZERO_BYTE_DELETE,
+                        target_id=finding.relative_path,
+                        status=CatalogRemediationOperationStatus.APPLIED,
+                        message="Zero-byte file was deleted from storage.",
+                        details={"absolute_path": finding.absolute_path},
+                    )
+                )
+            except Exception as exc:
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.ZERO_BYTE_FILE,
+                        action_kind=CatalogRemediationActionKind.ZERO_BYTE_DELETE,
+                        target_id=finding.relative_path,
+                        status=CatalogRemediationOperationStatus.FAILED,
+                        message=f"Deletion failed: {exc}",
+                    )
+                )
         return items
 
     def _apply_fuse_hidden_orphans(
@@ -615,17 +1210,11 @@ class CatalogRemediationService:
         for finding in findings:
             target_path = Path(finding.absolute_path)
             if not self.filesystem.is_child_path(uploads_root, target_path):
-                self._record_fuse_hidden_journal(
-                    settings,
-                    repair_run=repair_run,
-                    finding=finding,
-                    status=RepairJournalEntryStatus.SKIPPED,
-                    error_details={"reason": "Target path is outside the uploads root."},
-                )
                 items.append(
                     CatalogRemediationOperationItem(
                         finding_id=finding.finding_id,
                         kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        action_kind=CatalogRemediationActionKind.FUSE_HIDDEN_DELETE,
                         target_id=finding.relative_path,
                         status=CatalogRemediationOperationStatus.SKIPPED,
                         message="Target path is outside the uploads root and was not touched.",
@@ -633,17 +1222,11 @@ class CatalogRemediationService:
                 )
                 continue
             if not self.filesystem.path_exists(target_path):
-                self._record_fuse_hidden_journal(
-                    settings,
-                    repair_run=repair_run,
-                    finding=finding,
-                    status=RepairJournalEntryStatus.SKIPPED,
-                    error_details={"reason": "Artifact is already absent."},
-                )
                 items.append(
                     CatalogRemediationOperationItem(
                         finding_id=finding.finding_id,
                         kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        action_kind=CatalogRemediationActionKind.FUSE_HIDDEN_DELETE,
                         target_id=finding.relative_path,
                         status=CatalogRemediationOperationStatus.ALREADY_REMOVED,
                         message="Artifact is already absent from storage.",
@@ -652,47 +1235,45 @@ class CatalogRemediationService:
                 continue
             try:
                 self.filesystem.delete_file(target_path)
-            except Exception as exc:
-                self._record_fuse_hidden_journal(
+                self._record_storage_delete_journal(
                     settings,
                     repair_run=repair_run,
-                    finding=finding,
-                    status=RepairJournalEntryStatus.FAILED,
-                    error_details={"reason": str(exc)},
+                    finding_kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                    action_kind=CatalogRemediationActionKind.FUSE_HIDDEN_DELETE,
+                    target_id=finding.relative_path,
+                    absolute_path=finding.absolute_path,
+                    classification=finding.classification.value,
                 )
                 items.append(
                     CatalogRemediationOperationItem(
                         finding_id=finding.finding_id,
                         kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        action_kind=CatalogRemediationActionKind.FUSE_HIDDEN_DELETE,
+                        target_id=finding.relative_path,
+                        status=CatalogRemediationOperationStatus.APPLIED,
+                        message="Artifact was deleted from storage.",
+                        details={"absolute_path": finding.absolute_path},
+                    )
+                )
+            except Exception as exc:
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        action_kind=CatalogRemediationActionKind.FUSE_HIDDEN_DELETE,
                         target_id=finding.relative_path,
                         status=CatalogRemediationOperationStatus.FAILED,
                         message=f"Deletion failed: {exc}",
                     )
                 )
-                continue
-            self._record_fuse_hidden_journal(
-                settings,
-                repair_run=repair_run,
-                finding=finding,
-                status=RepairJournalEntryStatus.APPLIED,
-                error_details=None,
-            )
-            items.append(
-                CatalogRemediationOperationItem(
-                    finding_id=finding.finding_id,
-                    kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
-                    target_id=finding.relative_path,
-                    status=CatalogRemediationOperationStatus.APPLIED,
-                    message="Artifact was deleted from storage.",
-                    details={"absolute_path": finding.absolute_path},
-                )
-            )
         return items
 
     def _map_missing_asset_operation(
         self,
         finding_id: str,
         result: MissingAssetOperationItem,
+        *,
+        action_kind: CatalogRemediationActionKind,
     ) -> CatalogRemediationOperationItem:
         if result.status.value == "applied":
             mapped_status = CatalogRemediationOperationStatus.APPLIED
@@ -705,39 +1286,117 @@ class CatalogRemediationService:
         return CatalogRemediationOperationItem(
             finding_id=finding_id,
             kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+            action_kind=action_kind,
             target_id=result.asset_id,
             status=mapped_status,
             message=result.message,
             details=result.details,
         )
 
-    def _record_fuse_hidden_journal(
+    def _record_db_path_fix_journal(
         self,
         settings: AppSettings,
         *,
         repair_run: RepairRun,
-        finding: FuseHiddenOrphanFinding,
-        status: RepairJournalEntryStatus,
-        error_details: dict[str, object] | None,
+        finding: BrokenDbOriginalFinding,
+        old_original_path: str,
+        new_original_path: str,
     ) -> None:
         entry = RepairJournalEntry(
             entry_id=uuid4().hex,
             repair_run_id=repair_run.repair_run_id,
-            operation_type="delete_fuse_hidden_orphan",
-            status=status,
+            operation_type="fix_asset_original_path",
+            status=RepairJournalEntryStatus.APPLIED,
+            asset_id=finding.asset_id,
+            table="public.asset",
+            old_db_values={"originalPath": old_original_path},
+            new_db_values={"originalPath": new_original_path},
+            original_path=old_original_path,
+            quarantine_path=None,
+            undo_type=UndoType.RESTORE_DB_VALUES,
+            undo_payload={
+                "table": "public.asset",
+                "asset_id": finding.asset_id,
+                "old_values": {"originalPath": old_original_path},
+                "new_values": {"originalPath": new_original_path},
+            },
+            error_details=None,
+        )
+        self.repair_store.append_journal_entry(settings, entry)
+
+    def _record_storage_delete_journal(
+        self,
+        settings: AppSettings,
+        *,
+        repair_run: RepairRun,
+        finding_kind: CatalogRemediationFindingKind,
+        action_kind: CatalogRemediationActionKind,
+        target_id: str,
+        absolute_path: str,
+        classification: str,
+    ) -> None:
+        entry = RepairJournalEntry(
+            entry_id=uuid4().hex,
+            repair_run_id=repair_run.repair_run_id,
+            operation_type=action_kind.value,
+            status=RepairJournalEntryStatus.APPLIED,
             asset_id=None,
             table=None,
             old_db_values=None,
-            new_db_values={"absolute_path": finding.absolute_path}
-            if status == RepairJournalEntryStatus.APPLIED
-            else None,
-            original_path=finding.absolute_path,
+            new_db_values={
+                "finding_kind": finding_kind.value,
+                "target_id": target_id,
+                "absolute_path": absolute_path,
+                "classification": classification,
+            },
+            original_path=absolute_path,
             quarantine_path=None,
             undo_type=UndoType.NONE,
             undo_payload={},
-            error_details=error_details,
+            error_details=None,
         )
         self.repair_store.append_journal_entry(settings, entry)
+
+    def _asset_checksum_value(self, asset: dict[str, object]) -> str | None:
+        for key in ("checksum", "originalChecksum"):
+            value = truthy_path(asset.get(key))
+            if value is not None:
+                return value
+        return None
+
+    def _asset_checksum_algorithm(self, asset: dict[str, object]) -> str | None:
+        explicit_algorithm = truthy_path(asset.get("checksumAlgorithm"))
+        if explicit_algorithm is not None:
+            return explicit_algorithm.lower()
+        checksum_value = self._asset_checksum_value(asset)
+        if checksum_value is None:
+            return None
+        normalized = checksum_value.lower()
+        if normalized.startswith("\\x"):
+            normalized = normalized[2:]
+        if len(normalized) == 64 and all(char in "0123456789abcdef" for char in normalized):
+            return "sha256"
+        if len(normalized) == 40 and all(char in "0123456789abcdef" for char in normalized):
+            return "sha1"
+        return None
+
+    def _verify_file_checksum(
+        self,
+        *,
+        path: Path,
+        checksum_value: str,
+        checksum_algorithm: str,
+    ) -> bool | None:
+        if not self.filesystem.path_exists(path):
+            return None
+        normalized = checksum_value.strip().lower()
+        if normalized.startswith("\\x"):
+            normalized = normalized[2:]
+        try:
+            actual = self.filesystem.compute_file_checksum(path, algorithm=checksum_algorithm)
+        except Exception:
+            return None
+        return actual.lower() == normalized
 
     def _db_fingerprint(self, items: list[object]) -> str:
         return fingerprint_payload([self._fingerprintable_item(item) for item in items])
@@ -771,3 +1430,27 @@ class CatalogRemediationService:
                 "plan_token_id": repair_run.plan_token_id,
             },
         )
+
+    def _normalize_path_text(self, value: str) -> str:
+        return value.replace("\\", "/")
+
+    def _root_path_for(self, settings: AppSettings, *, root_slug: str) -> Path | None:
+        return {
+            "uploads": settings.immich_uploads_path,
+            "thumbs": settings.immich_thumbs_path,
+            "profile": settings.immich_profile_path,
+            "video": settings.immich_video_path,
+            "library": settings.immich_library_root,
+        }.get(root_slug)
+
+    def _absolute_path_for(
+        self,
+        settings: AppSettings,
+        *,
+        root_slug: str,
+        relative_path: str,
+    ) -> Path | None:
+        root_path = self._root_path_for(settings, root_slug=root_slug)
+        if root_path is None:
+            return None
+        return root_path / relative_path

--- a/immich_doctor/catalog/remediation_service.py
+++ b/immich_doctor/catalog/remediation_service.py
@@ -745,12 +745,10 @@ class CatalogRemediationService:
                             original_relative_path=relative_path,
                             eligible_actions=(),
                             action_reason=(
-                                "The zero-byte upload is referenced by the DB "
-                                "as the original file."
+                                "The zero-byte upload is referenced by the DB as the original file."
                             ),
                             message=(
-                                "The original upload is zero bytes and must "
-                                "not be auto-deleted."
+                                "The original upload is zero bytes and must not be auto-deleted."
                             ),
                         )
                     )
@@ -771,8 +769,7 @@ class CatalogRemediationService:
                         eligible_actions=(CatalogRemediationActionKind.ZERO_BYTE_DELETE,),
                         action_reason="The zero-byte upload has no DB original reference.",
                         message=(
-                            "The zero-byte upload is an orphan storage artifact "
-                            "and can be deleted."
+                            "The zero-byte upload is an orphan storage artifact and can be deleted."
                         ),
                     )
                 )
@@ -898,8 +895,7 @@ class CatalogRemediationService:
                         in_use_check_tool=tool,
                         in_use_check_reason=reason,
                         message=(
-                            "The orphan artifact can be deleted through an "
-                            "explicit apply step."
+                            "The orphan artifact can be deleted through an explicit apply step."
                         ),
                     )
                 )

--- a/immich_doctor/catalog/remediation_service.py
+++ b/immich_doctor/catalog/remediation_service.py
@@ -1,0 +1,773 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from uuid import uuid4
+
+from immich_doctor.adapters.external_tools import ExternalToolsAdapter
+from immich_doctor.adapters.filesystem import FilesystemAdapter
+from immich_doctor.adapters.postgres import PostgresAdapter
+from immich_doctor.catalog.consistency_state import (
+    SOURCE_ROOT_SLUG,
+    CatalogConsistencyStateCollector,
+)
+from immich_doctor.catalog.remediation_models import (
+    BrokenDbOriginalClassification,
+    BrokenDbOriginalFinding,
+    CatalogRemediationApplyResult,
+    CatalogRemediationFindingKind,
+    CatalogRemediationOperationItem,
+    CatalogRemediationOperationStatus,
+    CatalogRemediationPreviewResult,
+    CatalogRemediationScanResult,
+    FuseHiddenOrphanClassification,
+    FuseHiddenOrphanFinding,
+)
+from immich_doctor.consistency.missing_asset_models import (
+    MissingAssetOperationItem,
+    MissingAssetReferenceFinding,
+    MissingAssetReferenceStatus,
+    RepairReadinessStatus,
+)
+from immich_doctor.consistency.missing_asset_service import MissingAssetReferenceService
+from immich_doctor.core.config import AppSettings
+from immich_doctor.core.models import CheckResult, CheckStatus
+from immich_doctor.db.schema_detection import DatabaseStateDetector
+from immich_doctor.repair import (
+    RepairJournalEntry,
+    RepairJournalEntryStatus,
+    RepairJournalStore,
+    RepairRun,
+    RepairRunStatus,
+    UndoType,
+    build_live_state_fingerprint,
+    create_plan_token,
+    fingerprint_payload,
+    validate_plan_token,
+)
+from immich_doctor.repair.paths import repair_run_directory
+
+
+@dataclass(slots=True)
+class CatalogRemediationService:
+    postgres: PostgresAdapter = field(default_factory=PostgresAdapter)
+    filesystem: FilesystemAdapter = field(default_factory=FilesystemAdapter)
+    external_tools: ExternalToolsAdapter = field(default_factory=ExternalToolsAdapter)
+    repair_store: RepairJournalStore = field(default_factory=RepairJournalStore)
+
+    def scan(self, settings: AppSettings) -> CatalogRemediationScanResult:
+        snapshot_collector = CatalogConsistencyStateCollector(postgres=self.postgres)
+        snapshot_state = snapshot_collector.prepare_snapshot_state(settings)
+        if not snapshot_state.ready:
+            return CatalogRemediationScanResult(
+                summary="Catalog remediation is waiting for a current committed storage index.",
+                checks=snapshot_state.checks,
+                broken_db_originals=[],
+                fuse_hidden_orphans=[],
+                metadata=snapshot_state.metadata,
+                recommendations=[
+                    "Run a catalog scan from the Storage page before preparing "
+                    "remediation actions.",
+                ],
+            )
+
+        dsn = settings.postgres_dsn_value()
+        if not dsn:
+            return CatalogRemediationScanResult(
+                summary="Catalog remediation failed because database access is not configured.",
+                checks=[
+                    *snapshot_state.checks,
+                    CheckResult(
+                        name="postgres_connection",
+                        status=CheckStatus.FAIL,
+                        message="Database DSN is not configured.",
+                    ),
+                ],
+                broken_db_originals=[],
+                fuse_hidden_orphans=[],
+                metadata={"latestSnapshots": snapshot_state.latest_snapshots},
+            )
+
+        timeout = settings.postgres_connect_timeout_seconds
+        connection_check = self.postgres.validate_connection(dsn, timeout)
+        if connection_check.status == CheckStatus.FAIL:
+            return CatalogRemediationScanResult(
+                summary="Catalog remediation failed because PostgreSQL could not be reached.",
+                checks=[*snapshot_state.checks, connection_check],
+                broken_db_originals=[],
+                fuse_hidden_orphans=[],
+                metadata={"latestSnapshots": snapshot_state.latest_snapshots},
+            )
+
+        state = snapshot_collector.collect(settings)
+        broken_db_originals = self._build_broken_db_original_findings(settings, state=state)
+        fuse_hidden_orphans = self._build_fuse_hidden_findings(settings, state=state)
+        summary = (
+            "Catalog remediation classified "
+            f"{len(broken_db_originals)} broken DB originals and "
+            f"{len(fuse_hidden_orphans)} `.fuse_hidden*` orphan artifacts."
+        )
+        return CatalogRemediationScanResult(
+            summary=summary,
+            checks=state.checks,
+            broken_db_originals=broken_db_originals,
+            fuse_hidden_orphans=fuse_hidden_orphans,
+            metadata={
+                "configuredRoots": state.configured_root_slugs,
+                "latestSnapshots": state.latest_snapshots,
+                "snapshotBasis": state.snapshot_basis,
+                "latestScanCommittedAt": state.latest_scan_committed_at,
+                "totals": {
+                    "brokenDbOriginals": len(broken_db_originals),
+                    "brokenDbOriginalsEligible": sum(
+                        1 for item in broken_db_originals if item.action_eligible
+                    ),
+                    "fuseHiddenOrphans": len(fuse_hidden_orphans),
+                    "fuseHiddenOrphansEligible": sum(
+                        1 for item in fuse_hidden_orphans if item.action_eligible
+                    ),
+                },
+            },
+            recommendations=[
+                "Review `found_elsewhere` rows manually before considering any path rebind flow.",
+                "Only `missing_confirmed` and `deletable_orphan` rows become eligible for apply.",
+            ],
+        )
+
+    def preview_broken_db_originals(
+        self,
+        settings: AppSettings,
+        *,
+        asset_ids: tuple[str, ...],
+        select_all: bool,
+    ) -> CatalogRemediationPreviewResult:
+        scan_result = self.scan(settings)
+        selected_findings = self._select_broken_db_originals(
+            findings=scan_result.broken_db_originals,
+            asset_ids=asset_ids,
+            select_all=select_all,
+        )
+        return self._preview_result(
+            settings,
+            scan_result=scan_result,
+            finding_kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+            selected_items=[item.to_dict() for item in selected_findings],
+            selected_ids=[item.asset_id for item in selected_findings],
+            scope_key="asset_ids",
+            select_all=select_all,
+        )
+
+    def preview_fuse_hidden_orphans(
+        self,
+        settings: AppSettings,
+        *,
+        finding_ids: tuple[str, ...],
+        select_all: bool,
+    ) -> CatalogRemediationPreviewResult:
+        scan_result = self.scan(settings)
+        selected_findings = self._select_fuse_hidden_orphans(
+            findings=scan_result.fuse_hidden_orphans,
+            finding_ids=finding_ids,
+            select_all=select_all,
+        )
+        return self._preview_result(
+            settings,
+            scan_result=scan_result,
+            finding_kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+            selected_items=[item.to_dict() for item in selected_findings],
+            selected_ids=[item.finding_id for item in selected_findings],
+            scope_key="finding_ids",
+            select_all=select_all,
+        )
+
+    def apply(self, settings: AppSettings, *, repair_run_id: str) -> CatalogRemediationApplyResult:
+        run = self.repair_store.load_run(settings, repair_run_id)
+        plan_token = self.repair_store.load_plan_token(settings, repair_run_id)
+        finding_kind = CatalogRemediationFindingKind(str(run.scope["finding_kind"]))
+        scan_result = self.scan(settings)
+
+        if finding_kind == CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL:
+            selected_findings = self._select_broken_db_originals(
+                findings=scan_result.broken_db_originals,
+                asset_ids=tuple(str(item) for item in run.scope.get("asset_ids", [])),
+                select_all=bool(run.scope.get("select_all", False)),
+            )
+            current_scope_ids = [item.asset_id for item in selected_findings]
+            scope_key = "asset_ids"
+        else:
+            selected_findings = self._select_fuse_hidden_orphans(
+                findings=scan_result.fuse_hidden_orphans,
+                finding_ids=tuple(str(item) for item in run.scope.get("finding_ids", [])),
+                select_all=bool(run.scope.get("select_all", False)),
+            )
+            current_scope_ids = [item.finding_id for item in selected_findings]
+            scope_key = "finding_ids"
+
+        scope = dict(run.scope)
+        scope[scope_key] = current_scope_ids
+        guard_result = validate_plan_token(
+            plan_token,
+            scope=scope,
+            db_fingerprint=self._db_fingerprint(selected_findings),
+            file_fingerprint=self._file_fingerprint(selected_findings),
+        )
+        guard_check = CheckResult(
+            name="catalog_remediation_apply_guard",
+            status=CheckStatus.PASS if guard_result.valid else CheckStatus.FAIL,
+            message=guard_result.reason,
+            details={
+                "repair_run_id": repair_run_id,
+                "token_id": guard_result.token_id,
+                "expected_db_fingerprint": guard_result.expected_db_fingerprint,
+                "expected_file_fingerprint": guard_result.expected_file_fingerprint,
+                "actual_db_fingerprint": guard_result.actual_db_fingerprint,
+                "actual_file_fingerprint": guard_result.actual_file_fingerprint,
+            },
+        )
+        if not guard_result.valid:
+            run.finish(RepairRunStatus.FAILED)
+            self.repair_store.update_run(settings, run)
+            return CatalogRemediationApplyResult(
+                summary="Apply stopped because the preview scope drifted before mutation.",
+                checks=[*scan_result.checks, guard_check],
+                finding_kind=finding_kind,
+                repair_run_id=repair_run_id,
+                items=[],
+                metadata={"environment": settings.environment, "dry_run": False},
+                recommendations=[
+                    "Re-run preview to bind a fresh plan token to the current live state.",
+                ],
+            )
+
+        run.status = RepairRunStatus.RUNNING
+        self.repair_store.update_run(settings, run)
+        if finding_kind == CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL:
+            items = self._apply_broken_db_originals(
+                settings,
+                repair_run=run,
+                findings=selected_findings,
+            )
+        else:
+            items = self._apply_fuse_hidden_orphans(
+                settings,
+                repair_run=run,
+                findings=selected_findings,
+            )
+        run.finish(self._final_run_status(items))
+        self.repair_store.update_run(settings, run)
+        return CatalogRemediationApplyResult(
+            summary=f"Apply processed {len(items)} selected remediation items.",
+            checks=[*scan_result.checks, guard_check, self._journal_check(settings, run)],
+            finding_kind=finding_kind,
+            repair_run_id=repair_run_id,
+            items=items,
+            metadata={"environment": settings.environment, "dry_run": False},
+            recommendations=[
+                "Review the repair journal and any generated restore metadata "
+                "before follow-up actions.",
+            ],
+        )
+
+    def _preview_result(
+        self,
+        settings: AppSettings,
+        *,
+        scan_result: CatalogRemediationScanResult,
+        finding_kind: CatalogRemediationFindingKind,
+        selected_items: list[dict[str, object]],
+        selected_ids: list[str],
+        scope_key: str,
+        select_all: bool,
+    ) -> CatalogRemediationPreviewResult:
+        scope = {
+            "domain": "consistency.catalog_remediation",
+            "action": "preview",
+            "finding_kind": finding_kind.value,
+            scope_key: selected_ids,
+            "select_all": select_all,
+        }
+        plan_token = create_plan_token(
+            scope=scope,
+            db_fingerprint=self._db_fingerprint(selected_items),
+            file_fingerprint=self._file_fingerprint(selected_items),
+        )
+        repair_run = RepairRun.new(
+            repair_run_id=uuid4().hex,
+            scope=scope,
+            status=RepairRunStatus.PLANNED,
+            live_state_fingerprint=build_live_state_fingerprint(
+                db_fingerprint=plan_token.db_fingerprint,
+                file_fingerprint=plan_token.file_fingerprint,
+            ),
+            plan_token_id=plan_token.token_id,
+        )
+        self.repair_store.create_run(settings, repair_run=repair_run, plan_token=plan_token)
+        checks = list(scan_result.checks)
+        checks.append(
+            CheckResult(
+                name="catalog_remediation_preview_selection",
+                status=CheckStatus.PASS if selected_items else CheckStatus.WARN,
+                message=(
+                    f"Preview selected {len(selected_items)} eligible remediation items."
+                    if selected_items
+                    else "Preview selected no eligible remediation items."
+                ),
+                details={
+                    "select_all": select_all,
+                    "repair_run_id": repair_run.repair_run_id,
+                    "finding_kind": finding_kind.value,
+                },
+            )
+        )
+        checks.append(
+            CheckResult(
+                name="repair_run_foundation",
+                status=CheckStatus.PASS,
+                message="Preview persisted a repair run and plan token for later apply.",
+                details={
+                    "repair_run_id": repair_run.repair_run_id,
+                    "repair_run_path": str(
+                        repair_run_directory(settings, repair_run.repair_run_id)
+                    ),
+                    "plan_token_id": plan_token.token_id,
+                },
+            )
+        )
+        return CatalogRemediationPreviewResult(
+            summary=f"Preview planned {len(selected_items)} remediation items.",
+            checks=checks,
+            finding_kind=finding_kind,
+            repair_run_id=repair_run.repair_run_id,
+            selected_items=selected_items,
+            metadata={"environment": settings.environment, "dry_run": True},
+            recommendations=[
+                "Review the exact selected rows before apply and re-run preview "
+                "after any scan change.",
+            ],
+        )
+
+    def _build_broken_db_original_findings(
+        self,
+        settings: AppSettings,
+        *,
+        state,
+    ) -> list[BrokenDbOriginalFinding]:
+        files_by_name: dict[str, list[dict[str, object]]] = {}
+        for row in state.latest_files:
+            file_name = str(row.get("file_name") or "")
+            if file_name:
+                files_by_name.setdefault(file_name, []).append(row)
+
+        findings: list[BrokenDbOriginalFinding] = []
+        uploads_root = settings.immich_uploads_path
+        for row in state.db_missing_rows:
+            asset_name = str(row.get("asset_name") or "").strip() or None
+            try:
+                matches = files_by_name.get(asset_name or "", [])
+                relocated_match = next(
+                    (
+                        item
+                        for item in matches
+                        if str(item["root_slug"]) == SOURCE_ROOT_SLUG
+                        and str(item["relative_path"]) != str(row["relative_path"])
+                    ),
+                    None,
+                )
+                if relocated_match is not None and uploads_root is not None:
+                    found_relative_path = str(relocated_match["relative_path"])
+                    findings.append(
+                        BrokenDbOriginalFinding(
+                            finding_id=f"broken-db-original:{row['asset_id']}",
+                            kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+                            asset_id=str(row["asset_id"]),
+                            asset_name=asset_name,
+                            asset_type=str(row.get("asset_type") or "") or None,
+                            expected_database_path=str(row["database_path"]),
+                            expected_relative_path=str(row["relative_path"]),
+                            classification=BrokenDbOriginalClassification.FOUND_ELSEWHERE,
+                            action_eligible=False,
+                            action_reason=(
+                                "A file with the same name exists elsewhere in storage. "
+                                "This row is inspect-only by default."
+                            ),
+                            found_root_slug=str(relocated_match["root_slug"]),
+                            found_relative_path=found_relative_path,
+                            found_absolute_path=str(uploads_root / found_relative_path),
+                            found_size_bytes=int(relocated_match["size_bytes"]),
+                            expected_size_bytes=None,
+                            message=(
+                                "Expected storage path is missing, but a same-name file was found "
+                                "elsewhere in the cached storage inventory."
+                            ),
+                        )
+                    )
+                    continue
+                findings.append(
+                    BrokenDbOriginalFinding(
+                        finding_id=f"broken-db-original:{row['asset_id']}",
+                        kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+                        asset_id=str(row["asset_id"]),
+                        asset_name=asset_name,
+                        asset_type=str(row.get("asset_type") or "") or None,
+                        expected_database_path=str(row["database_path"]),
+                        expected_relative_path=str(row["relative_path"]),
+                        classification=BrokenDbOriginalClassification.MISSING_CONFIRMED,
+                        action_eligible=True,
+                        action_reason=(
+                            "The expected storage path is absent and no same-name relocation was "
+                            "found in the current cached storage inventory."
+                        ),
+                        message=(
+                            "Expected storage path is missing and the cached storage inventory "
+                            "found no same-name relocation."
+                        ),
+                    )
+                )
+            except Exception as exc:
+                findings.append(
+                    BrokenDbOriginalFinding(
+                        finding_id=f"broken-db-original:{row['asset_id']}",
+                        kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+                        asset_id=str(row["asset_id"]),
+                        asset_name=asset_name,
+                        asset_type=str(row.get("asset_type") or "") or None,
+                        expected_database_path=str(row["database_path"]),
+                        expected_relative_path=str(row["relative_path"]),
+                        classification=BrokenDbOriginalClassification.UNRESOLVED_SEARCH_ERROR,
+                        action_eligible=False,
+                        action_reason="Relocation search did not complete safely.",
+                        search_error=str(exc),
+                        message="Relocation search failed and the row remains inspect-only.",
+                    )
+                )
+        return findings
+
+    def _build_fuse_hidden_findings(
+        self,
+        settings: AppSettings,
+        *,
+        state,
+    ) -> list[FuseHiddenOrphanFinding]:
+        uploads_root = settings.immich_uploads_path
+        if uploads_root is None:
+            return []
+
+        findings: list[FuseHiddenOrphanFinding] = []
+        for row in state.storage_missing_rows:
+            file_name = str(row["file_name"])
+            if file_name == ".immich":
+                continue
+            if not file_name.startswith(".fuse_hidden"):
+                continue
+            absolute_path = uploads_root / str(row["relative_path"])
+            inspection = self.external_tools.inspect_open_file_handles(absolute_path)
+            tool = str(inspection.get("tool")) if inspection.get("tool") is not None else None
+            reason = str(inspection.get("reason") or "").strip() or None
+            status = str(inspection.get("status") or "")
+            if status == "in_use":
+                findings.append(
+                    FuseHiddenOrphanFinding(
+                        finding_id=f"fuse-hidden:{row['root_slug']}:{row['relative_path']}",
+                        kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        root_slug=str(row["root_slug"]),
+                        relative_path=str(row["relative_path"]),
+                        absolute_path=str(absolute_path),
+                        file_name=file_name,
+                        size_bytes=int(row["size_bytes"]),
+                        classification=FuseHiddenOrphanClassification.BLOCKED_IN_USE,
+                        action_eligible=False,
+                        action_reason="The orphan artifact is still held open by a process.",
+                        in_use_check_tool=tool,
+                        in_use_check_reason=reason,
+                        message="The file is still in use and cannot be removed safely.",
+                    )
+                )
+                continue
+            if status == "not_in_use":
+                findings.append(
+                    FuseHiddenOrphanFinding(
+                        finding_id=f"fuse-hidden:{row['root_slug']}:{row['relative_path']}",
+                        kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        root_slug=str(row["root_slug"]),
+                        relative_path=str(row["relative_path"]),
+                        absolute_path=str(absolute_path),
+                        file_name=file_name,
+                        size_bytes=int(row["size_bytes"]),
+                        classification=FuseHiddenOrphanClassification.DELETABLE_ORPHAN,
+                        action_eligible=True,
+                        action_reason="The orphan artifact is not reported as in use.",
+                        in_use_check_tool=tool,
+                        in_use_check_reason=reason,
+                        message=(
+                            "The orphan artifact can be deleted through an "
+                            "explicit apply step."
+                        ),
+                    )
+                )
+                continue
+            findings.append(
+                FuseHiddenOrphanFinding(
+                    finding_id=f"fuse-hidden:{row['root_slug']}:{row['relative_path']}",
+                    kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                    root_slug=str(row["root_slug"]),
+                    relative_path=str(row["relative_path"]),
+                    absolute_path=str(absolute_path),
+                    file_name=file_name,
+                    size_bytes=int(row["size_bytes"]),
+                    classification=FuseHiddenOrphanClassification.CHECK_FAILED,
+                    action_eligible=False,
+                    action_reason="The in-use check was unavailable or failed.",
+                    in_use_check_tool=tool,
+                    in_use_check_reason=reason,
+                    message="The in-use check could not be completed safely.",
+                )
+            )
+        return findings
+
+    def _select_broken_db_originals(
+        self,
+        *,
+        findings: list[BrokenDbOriginalFinding],
+        asset_ids: tuple[str, ...],
+        select_all: bool,
+    ) -> list[BrokenDbOriginalFinding]:
+        selected_ids = set(asset_ids)
+        return [
+            finding
+            for finding in findings
+            if finding.action_eligible and (select_all or finding.asset_id in selected_ids)
+        ]
+
+    def _select_fuse_hidden_orphans(
+        self,
+        *,
+        findings: list[FuseHiddenOrphanFinding],
+        finding_ids: tuple[str, ...],
+        select_all: bool,
+    ) -> list[FuseHiddenOrphanFinding]:
+        selected_ids = set(finding_ids)
+        return [
+            finding
+            for finding in findings
+            if finding.action_eligible and (select_all or finding.finding_id in selected_ids)
+        ]
+
+    def _apply_broken_db_originals(
+        self,
+        settings: AppSettings,
+        *,
+        repair_run: RepairRun,
+        findings: list[BrokenDbOriginalFinding],
+    ) -> list[CatalogRemediationOperationItem]:
+        dsn = settings.postgres_dsn_value()
+        if dsn is None:
+            return []
+        timeout = settings.postgres_connect_timeout_seconds
+        asset_service = MissingAssetReferenceService(
+            postgres=self.postgres,
+            filesystem=self.filesystem,
+            repair_store=self.repair_store,
+        )
+        profile = asset_service._detect_profile(
+            DatabaseStateDetector(self.postgres).detect(dsn, timeout)
+        )
+        items: list[CatalogRemediationOperationItem] = []
+        for finding in findings:
+            synthetic_finding = MissingAssetReferenceFinding(
+                finding_id=finding.finding_id,
+                asset_id=finding.asset_id,
+                asset_type=finding.asset_type or "unknown",
+                status=MissingAssetReferenceStatus.MISSING_ON_DISK,
+                logical_path=finding.expected_database_path,
+                resolved_physical_path=finding.expected_relative_path,
+                owner_id=None,
+                created_at=None,
+                updated_at=None,
+                scan_timestamp="",
+                repair_readiness=RepairReadinessStatus.READY,
+                repair_blockers=(),
+                repair_blocker_details=(),
+                message=finding.message,
+            )
+            result = asset_service._apply_single_asset(
+                settings,
+                dsn=dsn,
+                timeout=timeout,
+                asset_id=finding.asset_id,
+                finding=synthetic_finding,
+                repair_run=repair_run,
+                relations=profile.relations,
+            )
+            items.append(self._map_missing_asset_operation(finding.finding_id, result))
+        return items
+
+    def _apply_fuse_hidden_orphans(
+        self,
+        settings: AppSettings,
+        *,
+        repair_run: RepairRun,
+        findings: list[FuseHiddenOrphanFinding],
+    ) -> list[CatalogRemediationOperationItem]:
+        items: list[CatalogRemediationOperationItem] = []
+        uploads_root = settings.immich_uploads_path
+        if uploads_root is None:
+            return items
+        for finding in findings:
+            target_path = Path(finding.absolute_path)
+            if not self.filesystem.is_child_path(uploads_root, target_path):
+                self._record_fuse_hidden_journal(
+                    settings,
+                    repair_run=repair_run,
+                    finding=finding,
+                    status=RepairJournalEntryStatus.SKIPPED,
+                    error_details={"reason": "Target path is outside the uploads root."},
+                )
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        target_id=finding.relative_path,
+                        status=CatalogRemediationOperationStatus.SKIPPED,
+                        message="Target path is outside the uploads root and was not touched.",
+                    )
+                )
+                continue
+            if not self.filesystem.path_exists(target_path):
+                self._record_fuse_hidden_journal(
+                    settings,
+                    repair_run=repair_run,
+                    finding=finding,
+                    status=RepairJournalEntryStatus.SKIPPED,
+                    error_details={"reason": "Artifact is already absent."},
+                )
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        target_id=finding.relative_path,
+                        status=CatalogRemediationOperationStatus.ALREADY_REMOVED,
+                        message="Artifact is already absent from storage.",
+                    )
+                )
+                continue
+            try:
+                self.filesystem.delete_file(target_path)
+            except Exception as exc:
+                self._record_fuse_hidden_journal(
+                    settings,
+                    repair_run=repair_run,
+                    finding=finding,
+                    status=RepairJournalEntryStatus.FAILED,
+                    error_details={"reason": str(exc)},
+                )
+                items.append(
+                    CatalogRemediationOperationItem(
+                        finding_id=finding.finding_id,
+                        kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                        target_id=finding.relative_path,
+                        status=CatalogRemediationOperationStatus.FAILED,
+                        message=f"Deletion failed: {exc}",
+                    )
+                )
+                continue
+            self._record_fuse_hidden_journal(
+                settings,
+                repair_run=repair_run,
+                finding=finding,
+                status=RepairJournalEntryStatus.APPLIED,
+                error_details=None,
+            )
+            items.append(
+                CatalogRemediationOperationItem(
+                    finding_id=finding.finding_id,
+                    kind=CatalogRemediationFindingKind.FUSE_HIDDEN_ORPHAN,
+                    target_id=finding.relative_path,
+                    status=CatalogRemediationOperationStatus.APPLIED,
+                    message="Artifact was deleted from storage.",
+                    details={"absolute_path": finding.absolute_path},
+                )
+            )
+        return items
+
+    def _map_missing_asset_operation(
+        self,
+        finding_id: str,
+        result: MissingAssetOperationItem,
+    ) -> CatalogRemediationOperationItem:
+        if result.status.value == "applied":
+            mapped_status = CatalogRemediationOperationStatus.APPLIED
+        elif result.status.value == "already_removed":
+            mapped_status = CatalogRemediationOperationStatus.ALREADY_REMOVED
+        elif result.status.value == "failed":
+            mapped_status = CatalogRemediationOperationStatus.FAILED
+        else:
+            mapped_status = CatalogRemediationOperationStatus.SKIPPED
+        return CatalogRemediationOperationItem(
+            finding_id=finding_id,
+            kind=CatalogRemediationFindingKind.BROKEN_DB_ORIGINAL,
+            target_id=result.asset_id,
+            status=mapped_status,
+            message=result.message,
+            details=result.details,
+        )
+
+    def _record_fuse_hidden_journal(
+        self,
+        settings: AppSettings,
+        *,
+        repair_run: RepairRun,
+        finding: FuseHiddenOrphanFinding,
+        status: RepairJournalEntryStatus,
+        error_details: dict[str, object] | None,
+    ) -> None:
+        entry = RepairJournalEntry(
+            entry_id=uuid4().hex,
+            repair_run_id=repair_run.repair_run_id,
+            operation_type="delete_fuse_hidden_orphan",
+            status=status,
+            asset_id=None,
+            table=None,
+            old_db_values=None,
+            new_db_values={"absolute_path": finding.absolute_path}
+            if status == RepairJournalEntryStatus.APPLIED
+            else None,
+            original_path=finding.absolute_path,
+            quarantine_path=None,
+            undo_type=UndoType.NONE,
+            undo_payload={},
+            error_details=error_details,
+        )
+        self.repair_store.append_journal_entry(settings, entry)
+
+    def _db_fingerprint(self, items: list[object]) -> str:
+        return fingerprint_payload([self._fingerprintable_item(item) for item in items])
+
+    def _file_fingerprint(self, items: list[object]) -> str:
+        return fingerprint_payload([self._fingerprintable_item(item) for item in items])
+
+    def _fingerprintable_item(self, item: object) -> object:
+        if isinstance(item, dict):
+            return item
+        to_dict = getattr(item, "to_dict", None)
+        if callable(to_dict):
+            return to_dict()
+        return str(item)
+
+    def _final_run_status(self, items: list[CatalogRemediationOperationItem]) -> RepairRunStatus:
+        if any(item.status == CatalogRemediationOperationStatus.FAILED for item in items):
+            if any(item.status == CatalogRemediationOperationStatus.APPLIED for item in items):
+                return RepairRunStatus.PARTIAL
+            return RepairRunStatus.FAILED
+        return RepairRunStatus.COMPLETED
+
+    def _journal_check(self, settings: AppSettings, repair_run: RepairRun) -> CheckResult:
+        return CheckResult(
+            name="repair_journal",
+            status=CheckStatus.PASS,
+            message="Repair run foundation persisted manifest and journal files.",
+            details={
+                "repair_run_id": repair_run.repair_run_id,
+                "repair_run_path": str(repair_run_directory(settings, repair_run.repair_run_id)),
+                "plan_token_id": repair_run.plan_token_id,
+            },
+        )

--- a/tests/unit/test_api_consistency_route.py
+++ b/tests/unit/test_api_consistency_route.py
@@ -193,3 +193,96 @@ def test_catalog_consistency_job_routes_return_expected_shape(monkeypatch) -> No
     assert current_response.json()["data"]["result"]["progress"]["percent"] == 66.7
     assert start_response.status_code == 200
     assert start_response.json()["data"]["result"]["force"] is True
+
+
+def test_catalog_remediation_routes_return_expected_shape(monkeypatch) -> None:
+    monkeypatch.setattr(
+        consistency_routes.CatalogRemediationService,
+        "scan",
+        lambda self, settings: _Result(
+            {
+                "domain": "consistency.catalog_remediation",
+                "action": "scan",
+                "status": "WARN",
+                "summary": "Catalog remediation findings loaded.",
+                "broken_db_originals": [
+                    {"asset_id": "asset-1", "classification": "missing_confirmed"}
+                ],
+                "fuse_hidden_orphans": [
+                    {"finding_id": "fuse-1", "classification": "deletable_orphan"}
+                ],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        consistency_routes.CatalogRemediationService,
+        "preview_broken_db_originals",
+        lambda self, settings, **kwargs: _Result(
+            {
+                "domain": "consistency.catalog_remediation",
+                "action": "preview",
+                "status": "WARN",
+                "finding_kind": "broken_db_original",
+                "summary": "Preview selected 1 broken DB original.",
+                "repair_run_id": "repair-run-broken",
+                "selected_items": [{"asset_id": "asset-1"}],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        consistency_routes.CatalogRemediationService,
+        "preview_fuse_hidden_orphans",
+        lambda self, settings, **kwargs: _Result(
+            {
+                "domain": "consistency.catalog_remediation",
+                "action": "preview",
+                "status": "WARN",
+                "finding_kind": "fuse_hidden_orphan",
+                "summary": "Preview selected 1 fuse-hidden orphan.",
+                "repair_run_id": "repair-run-fuse",
+                "selected_items": [{"finding_id": "fuse-1"}],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        consistency_routes.CatalogRemediationService,
+        "apply",
+        lambda self, settings, **kwargs: _Result(
+            {
+                "domain": "consistency.catalog_remediation",
+                "action": "apply",
+                "status": "PASS",
+                "finding_kind": "fuse_hidden_orphan",
+                "summary": "Applied 1 remediation item.",
+                "repair_run_id": "repair-run-fuse",
+                "items": [{"finding_id": "fuse-1", "status": "applied"}],
+            }
+        ),
+    )
+    client = TestClient(create_api_app())
+
+    scan_response = client.get("/api/consistency/catalog-remediation/findings")
+    broken_preview_response = client.post(
+        "/api/consistency/catalog-remediation/broken-db-originals/preview",
+        json={"asset_ids": ["asset-1"], "select_all": False},
+    )
+    fuse_preview_response = client.post(
+        "/api/consistency/catalog-remediation/fuse-hidden-orphans/preview",
+        json={"finding_ids": ["fuse-1"], "select_all": False},
+    )
+    apply_response = client.post(
+        "/api/consistency/catalog-remediation/apply",
+        json={"repair_run_id": "repair-run-fuse"},
+    )
+
+    assert scan_response.status_code == 200
+    assert (
+        scan_response.json()["data"]["broken_db_originals"][0]["classification"]
+        == "missing_confirmed"
+    )
+    assert broken_preview_response.status_code == 200
+    assert broken_preview_response.json()["data"]["repair_run_id"] == "repair-run-broken"
+    assert fuse_preview_response.status_code == 200
+    assert fuse_preview_response.json()["data"]["repair_run_id"] == "repair-run-fuse"
+    assert apply_response.status_code == 200
+    assert apply_response.json()["data"]["items"][0]["status"] == "applied"

--- a/tests/unit/test_api_consistency_route.py
+++ b/tests/unit/test_api_consistency_route.py
@@ -199,7 +199,7 @@ def test_catalog_remediation_routes_return_expected_shape(monkeypatch) -> None:
     monkeypatch.setattr(
         consistency_routes.CatalogRemediationService,
         "scan",
-        lambda self, settings: _Result(
+        lambda self, settings, **kwargs: _Result(
             {
                 "domain": "consistency.catalog_remediation",
                 "action": "scan",
@@ -207,6 +207,9 @@ def test_catalog_remediation_routes_return_expected_shape(monkeypatch) -> None:
                 "summary": "Catalog remediation findings loaded.",
                 "broken_db_originals": [
                     {"asset_id": "asset-1", "classification": "missing_confirmed"}
+                ],
+                "zero_byte_findings": [
+                    {"finding_id": "zero-1", "classification": "zero_byte_upload_orphan"}
                 ],
                 "fuse_hidden_orphans": [
                     {"finding_id": "fuse-1", "classification": "deletable_orphan"}
@@ -216,16 +219,49 @@ def test_catalog_remediation_routes_return_expected_shape(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         consistency_routes.CatalogRemediationService,
-        "preview_broken_db_originals",
+        "preview_broken_db_cleanup",
         lambda self, settings, **kwargs: _Result(
             {
                 "domain": "consistency.catalog_remediation",
                 "action": "preview",
                 "status": "WARN",
                 "finding_kind": "broken_db_original",
+                "action_kind": "broken_db_cleanup",
                 "summary": "Preview selected 1 broken DB original.",
                 "repair_run_id": "repair-run-broken",
                 "selected_items": [{"asset_id": "asset-1"}],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        consistency_routes.CatalogRemediationService,
+        "preview_broken_db_path_fix",
+        lambda self, settings, **kwargs: _Result(
+            {
+                "domain": "consistency.catalog_remediation",
+                "action": "preview",
+                "status": "WARN",
+                "finding_kind": "broken_db_original",
+                "action_kind": "broken_db_path_fix",
+                "summary": "Preview selected 1 path-fix item.",
+                "repair_run_id": "repair-run-fix",
+                "selected_items": [{"asset_id": "asset-2"}],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        consistency_routes.CatalogRemediationService,
+        "preview_zero_byte_files",
+        lambda self, settings, **kwargs: _Result(
+            {
+                "domain": "consistency.catalog_remediation",
+                "action": "preview",
+                "status": "WARN",
+                "finding_kind": "zero_byte_file",
+                "action_kind": "zero_byte_delete",
+                "summary": "Preview selected 1 zero-byte item.",
+                "repair_run_id": "repair-run-zero",
+                "selected_items": [{"finding_id": "zero-1"}],
             }
         ),
     )
@@ -238,6 +274,7 @@ def test_catalog_remediation_routes_return_expected_shape(monkeypatch) -> None:
                 "action": "preview",
                 "status": "WARN",
                 "finding_kind": "fuse_hidden_orphan",
+                "action_kind": "fuse_hidden_delete",
                 "summary": "Preview selected 1 fuse-hidden orphan.",
                 "repair_run_id": "repair-run-fuse",
                 "selected_items": [{"finding_id": "fuse-1"}],
@@ -253,6 +290,7 @@ def test_catalog_remediation_routes_return_expected_shape(monkeypatch) -> None:
                 "action": "apply",
                 "status": "PASS",
                 "finding_kind": "fuse_hidden_orphan",
+                "action_kind": "fuse_hidden_delete",
                 "summary": "Applied 1 remediation item.",
                 "repair_run_id": "repair-run-fuse",
                 "items": [{"finding_id": "fuse-1", "status": "applied"}],
@@ -265,6 +303,14 @@ def test_catalog_remediation_routes_return_expected_shape(monkeypatch) -> None:
     broken_preview_response = client.post(
         "/api/consistency/catalog-remediation/broken-db-originals/preview",
         json={"asset_ids": ["asset-1"], "select_all": False},
+    )
+    path_fix_preview_response = client.post(
+        "/api/consistency/catalog-remediation/broken-db-originals/path-fix/preview",
+        json={"asset_ids": ["asset-2"], "select_all": False},
+    )
+    zero_byte_preview_response = client.post(
+        "/api/consistency/catalog-remediation/zero-byte-files/preview",
+        json={"finding_ids": ["zero-1"], "select_all": False},
     )
     fuse_preview_response = client.post(
         "/api/consistency/catalog-remediation/fuse-hidden-orphans/preview",
@@ -280,8 +326,16 @@ def test_catalog_remediation_routes_return_expected_shape(monkeypatch) -> None:
         scan_response.json()["data"]["broken_db_originals"][0]["classification"]
         == "missing_confirmed"
     )
+    assert (
+        scan_response.json()["data"]["zero_byte_findings"][0]["classification"]
+        == "zero_byte_upload_orphan"
+    )
     assert broken_preview_response.status_code == 200
     assert broken_preview_response.json()["data"]["repair_run_id"] == "repair-run-broken"
+    assert path_fix_preview_response.status_code == 200
+    assert path_fix_preview_response.json()["data"]["action_kind"] == "broken_db_path_fix"
+    assert zero_byte_preview_response.status_code == 200
+    assert zero_byte_preview_response.json()["data"]["repair_run_id"] == "repair-run-zero"
     assert fuse_preview_response.status_code == 200
     assert fuse_preview_response.json()["data"]["repair_run_id"] == "repair-run-fuse"
     assert apply_response.status_code == 200

--- a/tests/unit/test_catalog_consistency_service.py
+++ b/tests/unit/test_catalog_consistency_service.py
@@ -31,6 +31,7 @@ class _FakePostgres:
                 "originalFileName": "keep.jpg",
                 "originalPath": "/usr/src/app/upload/upload/user-a/keep.jpg",
                 "encodedVideoPath": "",
+                "livePhotoVideoId": None,
             },
             {
                 "id": "asset-missing",
@@ -41,6 +42,7 @@ class _FakePostgres:
                 "originalFileName": "missing.jpg",
                 "originalPath": "/usr/src/app/upload/upload/user-a/missing.jpg",
                 "encodedVideoPath": "/usr/src/app/upload/encoded-video/user-a/missing.mp4",
+                "livePhotoVideoId": None,
             },
         ]
 
@@ -131,6 +133,9 @@ def test_catalog_consistency_reports_db_storage_and_orphan_findings(tmp_path: Pa
     assert totals["storageOriginalsMissingInDb"] == 2
     assert totals["orphanDerivativesWithoutOriginal"] == 4
     assert totals["zeroByteFiles"] == 1
+    assert totals["filteredNoiseRemoved"] == 0
+    assert totals["validMotionVideoComponents"] == 0
+    assert totals["totalAssetsScanned"] == 2
 
     db_missing = next(
         section for section in report.sections if section.name == "DB_ORIGINALS_MISSING_ON_STORAGE"
@@ -223,3 +228,130 @@ def test_catalog_consistency_waits_for_current_snapshots_after_root_change(tmp_p
     assert report.metadata["requiresCurrentScan"] is True
     assert report.metadata["staleRootSlugs"] == ["uploads"]
     assert report.sections == []
+
+
+class _FakeMotionPostgres:
+    def validate_connection(self, dsn: str, timeout_seconds: int) -> CheckResult:
+        del dsn, timeout_seconds
+        return CheckResult(
+            name="postgres_connection",
+            status=CheckStatus.PASS,
+            message="PostgreSQL connection established.",
+        )
+
+    def list_all_assets_for_catalog_consistency(
+        self,
+        dsn: str,
+        timeout_seconds: int,
+    ) -> list[dict[str, object]]:
+        del dsn, timeout_seconds
+        return [
+            {
+                "id": "image-1",
+                "type": "image",
+                "ownerId": "user-1",
+                "createdAt": "2026-04-09T09:00:00+00:00",
+                "updatedAt": "2026-04-09T09:00:00+00:00",
+                "originalFileName": "live.jpg",
+                "originalPath": "/usr/src/app/upload/upload/user-a/live.jpg",
+                "encodedVideoPath": "",
+                "livePhotoVideoId": "video-1",
+            },
+            {
+                "id": "video-1",
+                "type": "video",
+                "ownerId": "user-1",
+                "createdAt": "2026-04-09T09:00:01+00:00",
+                "updatedAt": "2026-04-09T09:00:01+00:00",
+                "originalFileName": "live-motion.mp4",
+                "originalPath": "/usr/src/app/upload/encoded-video/user-a/live-motion-MP.mp4",
+                "encodedVideoPath": "",
+                "livePhotoVideoId": None,
+            },
+        ]
+
+    def list_all_asset_files_for_catalog_consistency(
+        self,
+        dsn: str,
+        timeout_seconds: int,
+    ) -> list[dict[str, object]]:
+        del dsn, timeout_seconds
+        return []
+
+
+def test_catalog_consistency_suppresses_valid_motion_video_component(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+
+    for path in [
+        settings.immich_uploads_path,
+        settings.immich_thumbs_path,
+        settings.immich_profile_path,
+        settings.immich_video_path,
+    ]:
+        assert path is not None
+        path.mkdir(parents=True, exist_ok=True)
+
+    (settings.immich_uploads_path / "user-a").mkdir(parents=True, exist_ok=True)
+    (settings.immich_video_path / "user-a").mkdir(parents=True, exist_ok=True)
+    (settings.immich_uploads_path / "user-a" / "live.jpg").write_bytes(b"image")
+    (settings.immich_video_path / "user-a" / "live-motion-MP.mp4").write_bytes(b"video")
+
+    for root_slug in ["uploads", "thumbs", "profile", "video"]:
+        CatalogInventoryScanService().run(
+            settings,
+            root_slug=root_slug,
+            resume_session_id=None,
+            max_files=None,
+        )
+
+    report = CatalogConsistencyValidationService(
+        postgres=_FakeMotionPostgres(),
+        sample_limit=20,
+    ).run(settings)
+
+    totals = report.metadata["totals"]
+    assert totals["dbOriginalsMissingOnStorage"] == 0
+    assert totals["unmappedDatabasePaths"] == 0
+    assert totals["filteredNoiseRemoved"] == 1
+    assert totals["validMotionVideoComponents"] == 1
+    assert totals["realIssuesRemaining"] == 0
+    assert "Suppressed 1 valid motion video components" in report.summary
+
+
+def test_catalog_consistency_reports_missing_motion_video_component_when_storage_file_missing(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path)
+
+    for path in [
+        settings.immich_uploads_path,
+        settings.immich_thumbs_path,
+        settings.immich_profile_path,
+        settings.immich_video_path,
+    ]:
+        assert path is not None
+        path.mkdir(parents=True, exist_ok=True)
+
+    (settings.immich_uploads_path / "user-a").mkdir(parents=True, exist_ok=True)
+    (settings.immich_uploads_path / "user-a" / "live.jpg").write_bytes(b"image")
+
+    for root_slug in ["uploads", "thumbs", "profile", "video"]:
+        CatalogInventoryScanService().run(
+            settings,
+            root_slug=root_slug,
+            resume_session_id=None,
+            max_files=None,
+        )
+
+    report = CatalogConsistencyValidationService(
+        postgres=_FakeMotionPostgres(),
+        sample_limit=20,
+    ).run(settings)
+
+    totals = report.metadata["totals"]
+    assert totals["dbOriginalsMissingOnStorage"] == 1
+    assert totals["unmappedDatabasePaths"] == 0
+    db_missing = next(
+        section for section in report.sections if section.name == "DB_ORIGINALS_MISSING_ON_STORAGE"
+    )
+    assert db_missing.rows[0]["classification"] == "valid_motion_video_component_missing_on_storage"

--- a/tests/unit/test_catalog_remediation_service.py
+++ b/tests/unit/test_catalog_remediation_service.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path
 
+from immich_doctor.catalog.remediation_models import CatalogRemediationActionKind
 from immich_doctor.catalog.remediation_service import CatalogRemediationService
 from immich_doctor.catalog.service import CatalogInventoryScanService
 from immich_doctor.core.config import AppSettings
@@ -19,6 +21,9 @@ class _FakeExternalTools:
 
 
 class _FakePostgres:
+    def __init__(self, checksum_value: str) -> None:
+        self.checksum_value = checksum_value
+
     def validate_connection(self, dsn: str, timeout_seconds: int) -> CheckResult:
         del dsn, timeout_seconds
         return CheckResult(
@@ -37,9 +42,6 @@ class _FakePostgres:
             {
                 "id": "asset-keep",
                 "type": "image",
-                "ownerId": "user-1",
-                "createdAt": "2026-04-09T09:00:00+00:00",
-                "updatedAt": "2026-04-09T09:00:00+00:00",
                 "originalFileName": "keep.jpg",
                 "originalPath": "/usr/src/app/upload/upload/user-a/keep.jpg",
                 "encodedVideoPath": "",
@@ -47,9 +49,6 @@ class _FakePostgres:
             {
                 "id": "asset-missing-confirmed",
                 "type": "image",
-                "ownerId": "user-1",
-                "createdAt": "2026-04-09T09:01:00+00:00",
-                "updatedAt": "2026-04-09T09:01:00+00:00",
                 "originalFileName": "confirmed.jpg",
                 "originalPath": "/usr/src/app/upload/upload/user-a/confirmed.jpg",
                 "encodedVideoPath": "",
@@ -57,11 +56,37 @@ class _FakePostgres:
             {
                 "id": "asset-found-elsewhere",
                 "type": "image",
-                "ownerId": "user-1",
-                "createdAt": "2026-04-09T09:02:00+00:00",
-                "updatedAt": "2026-04-09T09:02:00+00:00",
                 "originalFileName": "relocated.jpg",
                 "originalPath": "/usr/src/app/upload/upload/user-a/relocated.jpg",
+                "encodedVideoPath": "",
+            },
+            {
+                "id": "asset-path-fix",
+                "type": "image",
+                "originalFileName": "path-fix.jpg",
+                "originalPath": "/usr/src/app/upload/upload/user-a/path-fix.jpg",
+                "checksum": self.checksum_value,
+                "encodedVideoPath": "",
+            },
+            {
+                "id": "asset-zero-critical",
+                "type": "image",
+                "originalFileName": "critical-zero.jpg",
+                "originalPath": "/usr/src/app/upload/upload/user-a/critical-zero.jpg",
+                "encodedVideoPath": "",
+            },
+            {
+                "id": "asset-video",
+                "type": "video",
+                "originalFileName": "keep.jpg",
+                "originalPath": "/usr/src/app/upload/upload/user-a/keep.jpg",
+                "encodedVideoPath": "/usr/src/app/upload/encoded-video/user-a/video-zero.mp4",
+            },
+            {
+                "id": "asset-thumb",
+                "type": "image",
+                "originalFileName": "keep.jpg",
+                "originalPath": "/usr/src/app/upload/upload/user-a/keep.jpg",
                 "encodedVideoPath": "",
             },
         ]
@@ -72,7 +97,14 @@ class _FakePostgres:
         timeout_seconds: int,
     ) -> list[dict[str, object]]:
         del dsn, timeout_seconds
-        return []
+        return [
+            {
+                "id": "thumb-1",
+                "assetId": "asset-thumb",
+                "type": "thumbnail",
+                "path": "/usr/src/app/upload/thumbs/user-a/thumb-zero.webp",
+            }
+        ]
 
 
 def _settings(tmp_path: Path) -> AppSettings:
@@ -94,7 +126,7 @@ def _settings(tmp_path: Path) -> AppSettings:
     )
 
 
-def _build_scanned_settings(tmp_path: Path) -> AppSettings:
+def _build_scanned_settings(tmp_path: Path) -> tuple[AppSettings, str]:
     settings = _settings(tmp_path)
     for path in [
         settings.immich_uploads_path,
@@ -106,13 +138,24 @@ def _build_scanned_settings(tmp_path: Path) -> AppSettings:
         path.mkdir(parents=True, exist_ok=True)
 
     assert settings.immich_uploads_path is not None
+    assert settings.immich_thumbs_path is not None
+    assert settings.immich_video_path is not None
+
     (settings.immich_uploads_path / "user-a").mkdir(parents=True, exist_ok=True)
     (settings.immich_uploads_path / "user-b").mkdir(parents=True, exist_ok=True)
+    (settings.immich_thumbs_path / "user-a").mkdir(parents=True, exist_ok=True)
+    (settings.immich_video_path / "user-a").mkdir(parents=True, exist_ok=True)
+
     (settings.immich_uploads_path / "user-a" / "keep.jpg").write_bytes(b"ok")
+    (settings.immich_uploads_path / "user-a" / "path-fix.jpg").write_bytes(b"path-fix")
+    (settings.immich_uploads_path / "user-a" / "critical-zero.jpg").write_bytes(b"")
     (settings.immich_uploads_path / "user-a" / ".immich").write_bytes(b"marker")
     (settings.immich_uploads_path / "user-a" / ".fuse_hidden0001").write_bytes(b"blocked")
     (settings.immich_uploads_path / "user-b" / ".fuse_hidden0002").write_bytes(b"free")
     (settings.immich_uploads_path / "user-b" / "relocated.jpg").write_bytes(b"relocated")
+    (settings.immich_uploads_path / "user-b" / "orphan-zero.jpg").write_bytes(b"")
+    (settings.immich_thumbs_path / "user-a" / "thumb-zero.webp").write_bytes(b"")
+    (settings.immich_video_path / "user-a" / "video-zero.mp4").write_bytes(b"")
 
     for root_slug in ["uploads", "thumbs", "profile", "video"]:
         CatalogInventoryScanService().run(
@@ -121,16 +164,17 @@ def _build_scanned_settings(tmp_path: Path) -> AppSettings:
             resume_session_id=None,
             max_files=None,
         )
-    return settings
+    checksum_value = sha256(b"path-fix").hexdigest()
+    return settings, checksum_value
 
 
-def test_catalog_remediation_classifies_broken_db_originals_and_fuse_hidden_orphans(
+def test_catalog_remediation_classifies_broken_zero_byte_and_fuse_hidden_findings(
     tmp_path: Path,
 ) -> None:
-    settings = _build_scanned_settings(tmp_path)
+    settings, checksum_value = _build_scanned_settings(tmp_path)
     assert settings.immich_uploads_path is not None
     service = CatalogRemediationService(
-        postgres=_FakePostgres(),
+        postgres=_FakePostgres(checksum_value=checksum_value),
         external_tools=_FakeExternalTools(
             responses={
                 str(settings.immich_uploads_path / "user-a" / ".fuse_hidden0001"): {
@@ -155,6 +199,23 @@ def test_catalog_remediation_classifies_broken_db_originals_and_fuse_hidden_orph
     relocated = next(
         item for item in result.broken_db_originals if item.asset_id == "asset-found-elsewhere"
     )
+    hash_match = next(
+        item for item in result.broken_db_originals if item.asset_id == "asset-path-fix"
+    )
+    upload_orphan = next(
+        item for item in result.zero_byte_findings if item.relative_path == "user-b/orphan-zero.jpg"
+    )
+    upload_critical = next(
+        item
+        for item in result.zero_byte_findings
+        if item.relative_path == "user-a/critical-zero.jpg"
+    )
+    thumb_derivative = next(
+        item for item in result.zero_byte_findings if item.relative_path == "user-a/thumb-zero.webp"
+    )
+    video_derivative = next(
+        item for item in result.zero_byte_findings if item.relative_path == "user-a/video-zero.mp4"
+    )
     blocked = next(
         item
         for item in result.fuse_hidden_orphans
@@ -167,22 +228,31 @@ def test_catalog_remediation_classifies_broken_db_originals_and_fuse_hidden_orph
     )
 
     assert confirmed.classification.value == "missing_confirmed"
-    assert confirmed.action_eligible is True
+    assert confirmed.eligible_actions == (CatalogRemediationActionKind.BROKEN_DB_CLEANUP,)
     assert relocated.classification.value == "found_elsewhere"
     assert relocated.action_eligible is False
-    assert relocated.found_relative_path == "user-b/relocated.jpg"
+    assert hash_match.classification.value == "found_with_hash_match"
+    assert hash_match.checksum_match is True
+    assert hash_match.eligible_actions == (CatalogRemediationActionKind.BROKEN_DB_PATH_FIX,)
+    assert upload_orphan.classification.value == "zero_byte_upload_orphan"
+    assert upload_orphan.action_eligible is True
+    assert upload_critical.classification.value == "zero_byte_upload_critical"
+    assert upload_critical.action_eligible is False
+    assert thumb_derivative.classification.value == "zero_byte_thumb_derivative"
+    assert video_derivative.classification.value == "zero_byte_video_derivative"
     assert blocked.classification.value == "blocked_in_use"
     assert blocked.action_eligible is False
     assert deletable.classification.value == "deletable_orphan"
     assert deletable.action_eligible is True
     assert all(item.file_name != ".immich" for item in result.fuse_hidden_orphans)
+    assert all(item.file_name != ".immich" for item in result.zero_byte_findings)
 
 
 def test_catalog_remediation_bulk_preview_filters_to_eligible_items(tmp_path: Path) -> None:
-    settings = _build_scanned_settings(tmp_path)
+    settings, checksum_value = _build_scanned_settings(tmp_path)
     assert settings.immich_uploads_path is not None
     service = CatalogRemediationService(
-        postgres=_FakePostgres(),
+        postgres=_FakePostgres(checksum_value=checksum_value),
         external_tools=_FakeExternalTools(
             responses={
                 str(settings.immich_uploads_path / "user-a" / ".fuse_hidden0001"): {
@@ -199,11 +269,19 @@ def test_catalog_remediation_bulk_preview_filters_to_eligible_items(tmp_path: Pa
         ),
     )
 
-    broken_preview = service.preview_broken_db_originals(settings, asset_ids=(), select_all=True)
+    cleanup_preview = service.preview_broken_db_cleanup(settings, asset_ids=(), select_all=True)
+    path_fix_preview = service.preview_broken_db_path_fix(settings, asset_ids=(), select_all=True)
+    zero_byte_preview = service.preview_zero_byte_files(settings, finding_ids=(), select_all=True)
     fuse_preview = service.preview_fuse_hidden_orphans(settings, finding_ids=(), select_all=True)
 
-    assert [item["asset_id"] for item in broken_preview.selected_items] == [
+    assert [item["asset_id"] for item in cleanup_preview.selected_items] == [
         "asset-missing-confirmed"
+    ]
+    assert [item["asset_id"] for item in path_fix_preview.selected_items] == ["asset-path-fix"]
+    assert sorted(item["classification"] for item in zero_byte_preview.selected_items) == [
+        "zero_byte_thumb_derivative",
+        "zero_byte_upload_orphan",
+        "zero_byte_video_derivative",
     ]
     assert [item["relative_path"] for item in fuse_preview.selected_items] == [
         "user-b/.fuse_hidden0002"

--- a/tests/unit/test_catalog_remediation_service.py
+++ b/tests/unit/test_catalog_remediation_service.py
@@ -1,0 +1,210 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from immich_doctor.catalog.remediation_service import CatalogRemediationService
+from immich_doctor.catalog.service import CatalogInventoryScanService
+from immich_doctor.core.config import AppSettings
+from immich_doctor.core.models import CheckResult, CheckStatus
+
+
+@dataclass
+class _FakeExternalTools:
+    responses: dict[str, dict[str, object]]
+
+    def inspect_open_file_handles(self, path: Path) -> dict[str, object]:
+        return self.responses.get(
+            str(path),
+            {"status": "unavailable", "tool": "lsof", "reason": "lsof unavailable"},
+        )
+
+
+class _FakePostgres:
+    def validate_connection(self, dsn: str, timeout_seconds: int) -> CheckResult:
+        del dsn, timeout_seconds
+        return CheckResult(
+            name="postgres_connection",
+            status=CheckStatus.PASS,
+            message="PostgreSQL connection established.",
+        )
+
+    def list_all_assets_for_catalog_consistency(
+        self,
+        dsn: str,
+        timeout_seconds: int,
+    ) -> list[dict[str, object]]:
+        del dsn, timeout_seconds
+        return [
+            {
+                "id": "asset-keep",
+                "type": "image",
+                "ownerId": "user-1",
+                "createdAt": "2026-04-09T09:00:00+00:00",
+                "updatedAt": "2026-04-09T09:00:00+00:00",
+                "originalFileName": "keep.jpg",
+                "originalPath": "/usr/src/app/upload/upload/user-a/keep.jpg",
+                "encodedVideoPath": "",
+            },
+            {
+                "id": "asset-missing-confirmed",
+                "type": "image",
+                "ownerId": "user-1",
+                "createdAt": "2026-04-09T09:01:00+00:00",
+                "updatedAt": "2026-04-09T09:01:00+00:00",
+                "originalFileName": "confirmed.jpg",
+                "originalPath": "/usr/src/app/upload/upload/user-a/confirmed.jpg",
+                "encodedVideoPath": "",
+            },
+            {
+                "id": "asset-found-elsewhere",
+                "type": "image",
+                "ownerId": "user-1",
+                "createdAt": "2026-04-09T09:02:00+00:00",
+                "updatedAt": "2026-04-09T09:02:00+00:00",
+                "originalFileName": "relocated.jpg",
+                "originalPath": "/usr/src/app/upload/upload/user-a/relocated.jpg",
+                "encodedVideoPath": "",
+            },
+        ]
+
+    def list_all_asset_files_for_catalog_consistency(
+        self,
+        dsn: str,
+        timeout_seconds: int,
+    ) -> list[dict[str, object]]:
+        del dsn, timeout_seconds
+        return []
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings(
+        _env_file=None,
+        immich_uploads_path=tmp_path / "upload",
+        immich_thumbs_path=tmp_path / "thumbs",
+        immich_profile_path=tmp_path / "profile",
+        immich_video_path=tmp_path / "encoded-video",
+        manifests_path=tmp_path / "manifests",
+        reports_path=tmp_path / "reports",
+        quarantine_path=tmp_path / "quarantine",
+        logs_path=tmp_path / "logs",
+        tmp_path=tmp_path / "tmp",
+        db_host="postgres",
+        db_name="immich",
+        db_user="postgres",
+        db_password="secret",
+    )
+
+
+def _build_scanned_settings(tmp_path: Path) -> AppSettings:
+    settings = _settings(tmp_path)
+    for path in [
+        settings.immich_uploads_path,
+        settings.immich_thumbs_path,
+        settings.immich_profile_path,
+        settings.immich_video_path,
+    ]:
+        assert path is not None
+        path.mkdir(parents=True, exist_ok=True)
+
+    assert settings.immich_uploads_path is not None
+    (settings.immich_uploads_path / "user-a").mkdir(parents=True, exist_ok=True)
+    (settings.immich_uploads_path / "user-b").mkdir(parents=True, exist_ok=True)
+    (settings.immich_uploads_path / "user-a" / "keep.jpg").write_bytes(b"ok")
+    (settings.immich_uploads_path / "user-a" / ".immich").write_bytes(b"marker")
+    (settings.immich_uploads_path / "user-a" / ".fuse_hidden0001").write_bytes(b"blocked")
+    (settings.immich_uploads_path / "user-b" / ".fuse_hidden0002").write_bytes(b"free")
+    (settings.immich_uploads_path / "user-b" / "relocated.jpg").write_bytes(b"relocated")
+
+    for root_slug in ["uploads", "thumbs", "profile", "video"]:
+        CatalogInventoryScanService().run(
+            settings,
+            root_slug=root_slug,
+            resume_session_id=None,
+            max_files=None,
+        )
+    return settings
+
+
+def test_catalog_remediation_classifies_broken_db_originals_and_fuse_hidden_orphans(
+    tmp_path: Path,
+) -> None:
+    settings = _build_scanned_settings(tmp_path)
+    assert settings.immich_uploads_path is not None
+    service = CatalogRemediationService(
+        postgres=_FakePostgres(),
+        external_tools=_FakeExternalTools(
+            responses={
+                str(settings.immich_uploads_path / "user-a" / ".fuse_hidden0001"): {
+                    "status": "in_use",
+                    "tool": "lsof",
+                    "reason": "Open file handles were detected.",
+                },
+                str(settings.immich_uploads_path / "user-b" / ".fuse_hidden0002"): {
+                    "status": "not_in_use",
+                    "tool": "lsof",
+                    "reason": "No open file handles were reported.",
+                },
+            }
+        ),
+    )
+
+    result = service.scan(settings)
+
+    confirmed = next(
+        item for item in result.broken_db_originals if item.asset_id == "asset-missing-confirmed"
+    )
+    relocated = next(
+        item for item in result.broken_db_originals if item.asset_id == "asset-found-elsewhere"
+    )
+    blocked = next(
+        item
+        for item in result.fuse_hidden_orphans
+        if item.relative_path == "user-a/.fuse_hidden0001"
+    )
+    deletable = next(
+        item
+        for item in result.fuse_hidden_orphans
+        if item.relative_path == "user-b/.fuse_hidden0002"
+    )
+
+    assert confirmed.classification.value == "missing_confirmed"
+    assert confirmed.action_eligible is True
+    assert relocated.classification.value == "found_elsewhere"
+    assert relocated.action_eligible is False
+    assert relocated.found_relative_path == "user-b/relocated.jpg"
+    assert blocked.classification.value == "blocked_in_use"
+    assert blocked.action_eligible is False
+    assert deletable.classification.value == "deletable_orphan"
+    assert deletable.action_eligible is True
+    assert all(item.file_name != ".immich" for item in result.fuse_hidden_orphans)
+
+
+def test_catalog_remediation_bulk_preview_filters_to_eligible_items(tmp_path: Path) -> None:
+    settings = _build_scanned_settings(tmp_path)
+    assert settings.immich_uploads_path is not None
+    service = CatalogRemediationService(
+        postgres=_FakePostgres(),
+        external_tools=_FakeExternalTools(
+            responses={
+                str(settings.immich_uploads_path / "user-a" / ".fuse_hidden0001"): {
+                    "status": "in_use",
+                    "tool": "lsof",
+                    "reason": "Open file handles were detected.",
+                },
+                str(settings.immich_uploads_path / "user-b" / ".fuse_hidden0002"): {
+                    "status": "not_in_use",
+                    "tool": "lsof",
+                    "reason": "No open file handles were reported.",
+                },
+            }
+        ),
+    )
+
+    broken_preview = service.preview_broken_db_originals(settings, asset_ids=(), select_all=True)
+    fuse_preview = service.preview_fuse_hidden_orphans(settings, finding_ids=(), select_all=True)
+
+    assert [item["asset_id"] for item in broken_preview.selected_items] == [
+        "asset-missing-confirmed"
+    ]
+    assert [item["relative_path"] for item in fuse_preview.selected_items] == [
+        "user-b/.fuse_hidden0002"
+    ]

--- a/ui/frontend/src/api/consistency.ts
+++ b/ui/frontend/src/api/consistency.ts
@@ -1,6 +1,9 @@
 import { request } from "./client";
 import type { ApiResponse } from "./types/common";
-import type { CatalogJobRequest, CatalogWorkflowJobRecord } from "./types/catalog";
+import type {
+  CatalogJobRequest,
+  CatalogWorkflowJobRecord,
+} from "./types/catalog";
 import type {
   CatalogRemediationApplyResponse,
   CatalogRemediationPreviewRequest,
@@ -19,7 +22,9 @@ import type {
   MissingAssetScanResponse,
 } from "./types/consistency";
 
-export async function fetchMissingAssetFindings(): Promise<ApiResponse<MissingAssetScanResponse>> {
+export async function fetchMissingAssetFindings(): Promise<
+  ApiResponse<MissingAssetScanResponse>
+> {
   return request<MissingAssetScanResponse>(
     "/consistency/missing-asset-references/findings",
     undefined,
@@ -42,10 +47,13 @@ export async function previewMissingAssetRemovals(
 export async function applyMissingAssetRemovals(
   payload: MissingAssetApplyRequest,
 ): Promise<ApiResponse<MissingAssetApplyResponse>> {
-  return request<MissingAssetApplyResponse>("/consistency/missing-asset-references/apply", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  return request<MissingAssetApplyResponse>(
+    "/consistency/missing-asset-references/apply",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
 }
 
 export async function fetchMissingAssetRestorePoints(): Promise<
@@ -89,7 +97,21 @@ export async function fetchCatalogConsistencyJob(): Promise<
 export async function fetchCatalogRemediationFindings(): Promise<
   ApiResponse<CatalogRemediationScanResponse>
 > {
-  return request<CatalogRemediationScanResponse>("/consistency/catalog-remediation/findings");
+  return request<CatalogRemediationScanResponse>(
+    "/consistency/catalog-remediation/findings",
+  );
+}
+
+export async function fetchCatalogRemediationFindingsByClassification(
+  classifications: string[],
+): Promise<ApiResponse<CatalogRemediationScanResponse>> {
+  const query = new URLSearchParams();
+  for (const classification of classifications) {
+    query.append("classification", classification);
+  }
+  return request<CatalogRemediationScanResponse>(
+    `/consistency/catalog-remediation/findings?${query.toString()}`,
+  );
 }
 
 export async function previewBrokenDbOriginalRemediation(
@@ -97,6 +119,30 @@ export async function previewBrokenDbOriginalRemediation(
 ): Promise<ApiResponse<CatalogRemediationPreviewResponse>> {
   return request<CatalogRemediationPreviewResponse>(
     "/consistency/catalog-remediation/broken-db-originals/preview",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function previewBrokenDbPathFixRemediation(
+  payload: CatalogRemediationPreviewRequest,
+): Promise<ApiResponse<CatalogRemediationPreviewResponse>> {
+  return request<CatalogRemediationPreviewResponse>(
+    "/consistency/catalog-remediation/broken-db-originals/path-fix/preview",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function previewZeroByteRemediation(
+  payload: CatalogRemediationPreviewRequest,
+): Promise<ApiResponse<CatalogRemediationPreviewResponse>> {
+  return request<CatalogRemediationPreviewResponse>(
+    "/consistency/catalog-remediation/zero-byte-files/preview",
     {
       method: "POST",
       body: JSON.stringify(payload),
@@ -119,10 +165,13 @@ export async function previewFuseHiddenRemediation(
 export async function applyCatalogRemediation(
   repairRunId: string,
 ): Promise<ApiResponse<CatalogRemediationApplyResponse>> {
-  return request<CatalogRemediationApplyResponse>("/consistency/catalog-remediation/apply", {
-    method: "POST",
-    body: JSON.stringify({ repair_run_id: repairRunId }),
-  });
+  return request<CatalogRemediationApplyResponse>(
+    "/consistency/catalog-remediation/apply",
+    {
+      method: "POST",
+      body: JSON.stringify({ repair_run_id: repairRunId }),
+    },
+  );
 }
 
 export async function startCatalogConsistencyJob(

--- a/ui/frontend/src/api/consistency.ts
+++ b/ui/frontend/src/api/consistency.ts
@@ -2,6 +2,10 @@ import { request } from "./client";
 import type { ApiResponse } from "./types/common";
 import type { CatalogJobRequest, CatalogWorkflowJobRecord } from "./types/catalog";
 import type {
+  CatalogRemediationApplyResponse,
+  CatalogRemediationPreviewRequest,
+  CatalogRemediationPreviewResponse,
+  CatalogRemediationScanResponse,
   MissingAssetApplyRequest,
   MissingAssetApplyResponse,
   MissingAssetPreviewRequest,
@@ -80,6 +84,45 @@ export async function fetchCatalogConsistencyJob(): Promise<
   ApiResponse<CatalogWorkflowJobRecord>
 > {
   return request<CatalogWorkflowJobRecord>("/consistency/catalog");
+}
+
+export async function fetchCatalogRemediationFindings(): Promise<
+  ApiResponse<CatalogRemediationScanResponse>
+> {
+  return request<CatalogRemediationScanResponse>("/consistency/catalog-remediation/findings");
+}
+
+export async function previewBrokenDbOriginalRemediation(
+  payload: CatalogRemediationPreviewRequest,
+): Promise<ApiResponse<CatalogRemediationPreviewResponse>> {
+  return request<CatalogRemediationPreviewResponse>(
+    "/consistency/catalog-remediation/broken-db-originals/preview",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function previewFuseHiddenRemediation(
+  payload: CatalogRemediationPreviewRequest,
+): Promise<ApiResponse<CatalogRemediationPreviewResponse>> {
+  return request<CatalogRemediationPreviewResponse>(
+    "/consistency/catalog-remediation/fuse-hidden-orphans/preview",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function applyCatalogRemediation(
+  repairRunId: string,
+): Promise<ApiResponse<CatalogRemediationApplyResponse>> {
+  return request<CatalogRemediationApplyResponse>("/consistency/catalog-remediation/apply", {
+    method: "POST",
+    body: JSON.stringify({ repair_run_id: repairRunId }),
+  });
 }
 
 export async function startCatalogConsistencyJob(

--- a/ui/frontend/src/api/types/consistency.ts
+++ b/ui/frontend/src/api/types/consistency.ts
@@ -185,3 +185,109 @@ export interface MissingAssetRestorePointDeleteResponse {
   }>;
   metadata: Record<string, unknown>;
 }
+
+export type CatalogRemediationFindingKind = "broken_db_original" | "fuse_hidden_orphan";
+export type BrokenDbOriginalClassification =
+  | "missing_confirmed"
+  | "found_elsewhere"
+  | "unresolved_search_error";
+export type FuseHiddenOrphanClassification =
+  | "blocked_in_use"
+  | "deletable_orphan"
+  | "check_failed";
+export type CatalogRemediationOperationStatus =
+  | "planned"
+  | "applied"
+  | "skipped"
+  | "failed"
+  | "already_removed";
+
+export interface BrokenDbOriginalFinding {
+  finding_id: string;
+  kind: "broken_db_original";
+  asset_id: string;
+  asset_name: string | null;
+  asset_type: string | null;
+  expected_database_path: string;
+  expected_relative_path: string;
+  classification: BrokenDbOriginalClassification;
+  action_eligible: boolean;
+  action_reason: string;
+  found_root_slug: string | null;
+  found_relative_path: string | null;
+  found_absolute_path: string | null;
+  found_size_bytes: number | null;
+  expected_size_bytes: number | null;
+  search_error: string | null;
+  message: string;
+}
+
+export interface FuseHiddenOrphanFinding {
+  finding_id: string;
+  kind: "fuse_hidden_orphan";
+  root_slug: string;
+  relative_path: string;
+  absolute_path: string;
+  file_name: string;
+  size_bytes: number;
+  classification: FuseHiddenOrphanClassification;
+  action_eligible: boolean;
+  action_reason: string;
+  in_use_check_tool: string | null;
+  in_use_check_reason: string | null;
+  message: string;
+}
+
+export interface CatalogRemediationScanResponse {
+  domain: string;
+  action: string;
+  status: string;
+  summary: string;
+  generated_at: string;
+  checks: RuntimeCheckResult[];
+  broken_db_originals: BrokenDbOriginalFinding[];
+  fuse_hidden_orphans: FuseHiddenOrphanFinding[];
+  metadata: Record<string, unknown>;
+  recommendations: string[];
+}
+
+export interface CatalogRemediationPreviewRequest {
+  asset_ids?: string[];
+  finding_ids?: string[];
+  select_all: boolean;
+}
+
+export interface CatalogRemediationPreviewResponse {
+  domain: string;
+  action: string;
+  status: string;
+  summary: string;
+  generated_at: string;
+  checks: RuntimeCheckResult[];
+  finding_kind: CatalogRemediationFindingKind;
+  repair_run_id: string;
+  selected_items: Array<Record<string, unknown>>;
+  metadata: Record<string, unknown>;
+  recommendations: string[];
+}
+
+export interface CatalogRemediationApplyResponse {
+  domain: string;
+  action: string;
+  status: string;
+  summary: string;
+  generated_at: string;
+  checks: RuntimeCheckResult[];
+  finding_kind: CatalogRemediationFindingKind;
+  repair_run_id: string;
+  items: Array<{
+    finding_id: string;
+    kind: CatalogRemediationFindingKind;
+    target_id: string;
+    status: CatalogRemediationOperationStatus;
+    message: string;
+    details: Record<string, unknown>;
+  }>;
+  metadata: Record<string, unknown>;
+  recommendations: string[];
+}

--- a/ui/frontend/src/api/types/consistency.ts
+++ b/ui/frontend/src/api/types/consistency.ts
@@ -186,11 +186,26 @@ export interface MissingAssetRestorePointDeleteResponse {
   metadata: Record<string, unknown>;
 }
 
-export type CatalogRemediationFindingKind = "broken_db_original" | "fuse_hidden_orphan";
+export type CatalogRemediationFindingKind =
+  | "broken_db_original"
+  | "zero_byte_file"
+  | "fuse_hidden_orphan";
+export type CatalogRemediationActionKind =
+  | "broken_db_cleanup"
+  | "broken_db_path_fix"
+  | "zero_byte_delete"
+  | "fuse_hidden_delete";
 export type BrokenDbOriginalClassification =
   | "missing_confirmed"
   | "found_elsewhere"
+  | "found_with_hash_match"
   | "unresolved_search_error";
+export type ZeroByteClassification =
+  | "zero_byte_upload_orphan"
+  | "zero_byte_upload_critical"
+  | "zero_byte_video_derivative"
+  | "zero_byte_thumb_derivative"
+  | "ignore_internal";
 export type FuseHiddenOrphanClassification =
   | "blocked_in_use"
   | "deletable_orphan"
@@ -208,9 +223,14 @@ export interface BrokenDbOriginalFinding {
   asset_id: string;
   asset_name: string | null;
   asset_type: string | null;
+  expected_absolute_path: string | null;
   expected_database_path: string;
   expected_relative_path: string;
   classification: BrokenDbOriginalClassification;
+  checksum_value: string | null;
+  checksum_algorithm: string | null;
+  checksum_match: boolean | null;
+  eligible_actions: CatalogRemediationActionKind[];
   action_eligible: boolean;
   action_reason: string;
   found_root_slug: string | null;
@@ -219,6 +239,24 @@ export interface BrokenDbOriginalFinding {
   found_size_bytes: number | null;
   expected_size_bytes: number | null;
   search_error: string | null;
+  message: string;
+}
+
+export interface ZeroByteFinding {
+  finding_id: string;
+  kind: "zero_byte_file";
+  root_slug: string;
+  relative_path: string;
+  absolute_path: string;
+  file_name: string;
+  size_bytes: number;
+  classification: ZeroByteClassification;
+  asset_id: string | null;
+  asset_name: string | null;
+  original_relative_path: string | null;
+  eligible_actions: CatalogRemediationActionKind[];
+  action_eligible: boolean;
+  action_reason: string;
   message: string;
 }
 
@@ -231,6 +269,7 @@ export interface FuseHiddenOrphanFinding {
   file_name: string;
   size_bytes: number;
   classification: FuseHiddenOrphanClassification;
+  eligible_actions: CatalogRemediationActionKind[];
   action_eligible: boolean;
   action_reason: string;
   in_use_check_tool: string | null;
@@ -246,6 +285,7 @@ export interface CatalogRemediationScanResponse {
   generated_at: string;
   checks: RuntimeCheckResult[];
   broken_db_originals: BrokenDbOriginalFinding[];
+  zero_byte_findings: ZeroByteFinding[];
   fuse_hidden_orphans: FuseHiddenOrphanFinding[];
   metadata: Record<string, unknown>;
   recommendations: string[];
@@ -265,6 +305,7 @@ export interface CatalogRemediationPreviewResponse {
   generated_at: string;
   checks: RuntimeCheckResult[];
   finding_kind: CatalogRemediationFindingKind;
+  action_kind: CatalogRemediationActionKind;
   repair_run_id: string;
   selected_items: Array<Record<string, unknown>>;
   metadata: Record<string, unknown>;
@@ -279,10 +320,12 @@ export interface CatalogRemediationApplyResponse {
   generated_at: string;
   checks: RuntimeCheckResult[];
   finding_kind: CatalogRemediationFindingKind;
+  action_kind: CatalogRemediationActionKind;
   repair_run_id: string;
   items: Array<{
     finding_id: string;
     kind: CatalogRemediationFindingKind;
+    action_kind: CatalogRemediationActionKind;
     target_id: string;
     status: CatalogRemediationOperationStatus;
     message: string;

--- a/ui/frontend/src/components/consistency/CatalogRemediationPanel.spec.ts
+++ b/ui/frontend/src/components/consistency/CatalogRemediationPanel.spec.ts
@@ -19,24 +19,88 @@ function createStore(): any {
         asset_type: "image",
         expected_database_path: "/usr/src/app/upload/upload/user-a/missing.jpg",
         expected_relative_path: "user-a/missing.jpg",
+        expected_absolute_path: "/upload/user-a/missing.jpg",
         classification: "missing_confirmed",
+        checksum_value: null,
+        checksum_algorithm: null,
+        checksum_match: null,
+        eligible_actions: ["broken_db_cleanup"],
         action_eligible: true,
-        action_reason: "Eligible",
+        action_reason: "Eligible for cleanup",
         found_absolute_path: null,
         message: "Missing confirmed.",
       },
       {
         finding_id: "broken-2",
         asset_id: "asset-2",
+        asset_name: "path-fix.jpg",
+        asset_type: "image",
+        expected_database_path:
+          "/usr/src/app/upload/upload/user-a/path-fix.jpg",
+        expected_relative_path: "user-a/path-fix.jpg",
+        expected_absolute_path: "/upload/user-a/path-fix.jpg",
+        classification: "found_with_hash_match",
+        checksum_value: "abc",
+        checksum_algorithm: "sha256",
+        checksum_match: true,
+        eligible_actions: ["broken_db_path_fix"],
+        action_eligible: true,
+        action_reason: "Eligible for path fix",
+        found_absolute_path: "/upload/user-a/path-fix.jpg",
+        message: "Hash match.",
+      },
+      {
+        finding_id: "broken-3",
+        asset_id: "asset-3",
         asset_name: "relocated.jpg",
         asset_type: "image",
-        expected_database_path: "/usr/src/app/upload/upload/user-a/relocated.jpg",
+        expected_database_path:
+          "/usr/src/app/upload/upload/user-a/relocated.jpg",
         expected_relative_path: "user-a/relocated.jpg",
+        expected_absolute_path: "/upload/user-a/relocated.jpg",
         classification: "found_elsewhere",
+        checksum_value: null,
+        checksum_algorithm: null,
+        checksum_match: null,
+        eligible_actions: [],
         action_eligible: false,
         action_reason: "Inspect only",
         found_absolute_path: "/upload/user-b/relocated.jpg",
         message: "Found elsewhere.",
+      },
+    ],
+    zeroByteFindings: [
+      {
+        finding_id: "zero-1",
+        root_slug: "uploads",
+        relative_path: "user-a/orphan-zero.jpg",
+        absolute_path: "/upload/user-a/orphan-zero.jpg",
+        file_name: "orphan-zero.jpg",
+        size_bytes: 0,
+        classification: "zero_byte_upload_orphan",
+        asset_id: null,
+        asset_name: null,
+        original_relative_path: null,
+        eligible_actions: ["zero_byte_delete"],
+        action_eligible: true,
+        action_reason: "Delete allowed",
+        message: "Orphan zero-byte upload.",
+      },
+      {
+        finding_id: "zero-2",
+        root_slug: "uploads",
+        relative_path: "user-a/critical-zero.jpg",
+        absolute_path: "/upload/user-a/critical-zero.jpg",
+        file_name: "critical-zero.jpg",
+        size_bytes: 0,
+        classification: "zero_byte_upload_critical",
+        asset_id: "asset-4",
+        asset_name: "critical-zero.jpg",
+        original_relative_path: "user-a/critical-zero.jpg",
+        eligible_actions: [],
+        action_eligible: false,
+        action_reason: "Blocked",
+        message: "Critical original.",
       },
     ],
     fuseHiddenOrphans: [
@@ -48,6 +112,7 @@ function createStore(): any {
         file_name: ".fuse_hidden0001",
         size_bytes: 123,
         classification: "blocked_in_use",
+        eligible_actions: [],
         action_eligible: false,
         action_reason: "Blocked",
         message: "Still in use.",
@@ -60,6 +125,7 @@ function createStore(): any {
         file_name: ".fuse_hidden0002",
         size_bytes: 456,
         classification: "deletable_orphan",
+        eligible_actions: ["fuse_hidden_delete"],
         action_eligible: true,
         action_reason: "Eligible",
         message: "Safe to delete.",
@@ -70,11 +136,19 @@ function createStore(): any {
     isApplying: false,
     loadRemediation: vi.fn().mockResolvedValue(undefined),
     previewBrokenDbOriginals: vi.fn().mockResolvedValue({
-      summary: "Preview planned 1 remediation item.",
-      repair_run_id: "broken-run",
+      summary: "Preview planned 1 cleanup item.",
+      repair_run_id: "broken-cleanup-run",
+    }),
+    previewBrokenDbPathFix: vi.fn().mockResolvedValue({
+      summary: "Preview planned 1 path-fix item.",
+      repair_run_id: "broken-fix-run",
+    }),
+    previewZeroByte: vi.fn().mockResolvedValue({
+      summary: "Preview planned 1 zero-byte item.",
+      repair_run_id: "zero-run",
     }),
     previewFuseHidden: vi.fn().mockResolvedValue({
-      summary: "Preview planned 1 remediation item.",
+      summary: "Preview planned 1 fuse-hidden item.",
       repair_run_id: "fuse-run",
     }),
     applyRemediation: vi.fn().mockResolvedValue({
@@ -95,30 +169,65 @@ describe("CatalogRemediationPanel", () => {
     vi.clearAllMocks();
   });
 
-  it("previews only eligible broken DB originals and keeps found_elsewhere inspect-only", async () => {
+  it("separates cleanup and path-fix preview selections for broken DB rows", async () => {
     const wrapper = mount(CatalogRemediationPanel, {
       global: {
         stubs: {
-          StatusTag: { template: "<span>{{ status }}</span>", props: ["status"] },
+          StatusTag: {
+            template: "<span>{{ status }}</span>",
+            props: ["status"],
+          },
         },
       },
     });
     await nextTick();
 
-    const brokenCheckboxes = wrapper.findAll("tbody input[type='checkbox']");
-    expect((brokenCheckboxes[1].element as HTMLInputElement).disabled).toBe(true);
-
-    await brokenCheckboxes[0].setValue(true);
+    const checkboxes = wrapper.findAll("tbody input[type='checkbox']");
+    await checkboxes[0].setValue(true);
+    await checkboxes[1].setValue(true);
     await nextTick();
 
-    const previewButton = wrapper
-      .findAll("button")
-      .find((button) => button.text().includes("Preview selected (1)"));
-    await previewButton!.trigger("click");
+    await wrapper.findAll("button")[1].trigger("click");
     await nextTick();
-
     expect(store.previewBrokenDbOriginals).toHaveBeenCalledWith({
       asset_ids: ["asset-1"],
+      select_all: false,
+    });
+
+    await wrapper.findAll("button")[3].trigger("click");
+    await nextTick();
+    expect(store.previewBrokenDbPathFix).toHaveBeenCalledWith({
+      asset_ids: ["asset-2"],
+      select_all: false,
+    });
+  });
+
+  it("previews only eligible zero-byte items and blocks critical originals", async () => {
+    const wrapper = mount(CatalogRemediationPanel, {
+      global: {
+        stubs: {
+          StatusTag: {
+            template: "<span>{{ status }}</span>",
+            props: ["status"],
+          },
+        },
+      },
+    });
+    await nextTick();
+
+    const checkboxes = wrapper.findAll("tbody input[type='checkbox']");
+    expect((checkboxes[4].element as HTMLInputElement).disabled).toBe(true);
+
+    await checkboxes[3].setValue(true);
+    await nextTick();
+    const previewSelectedButtons = wrapper
+      .findAll("button")
+      .filter((button) => button.text().includes("Preview selected (1)"));
+    await previewSelectedButtons[0].trigger("click");
+    await nextTick();
+
+    expect(store.previewZeroByte).toHaveBeenCalledWith({
+      finding_ids: ["zero-1"],
       select_all: false,
     });
   });
@@ -127,26 +236,31 @@ describe("CatalogRemediationPanel", () => {
     const wrapper = mount(CatalogRemediationPanel, {
       global: {
         stubs: {
-          StatusTag: { template: "<span>{{ status }}</span>", props: ["status"] },
+          StatusTag: {
+            template: "<span>{{ status }}</span>",
+            props: ["status"],
+          },
         },
       },
     });
     await nextTick();
 
-    const previewAllFuseButton = wrapper
+    const previewAllButtons = wrapper
       .findAll("button")
-      .filter((button) => button.text().includes("Preview all eligible (1)"))[1];
-    await previewAllFuseButton!.trigger("click");
+      .filter((button) => button.text().includes("Preview all eligible (1)"));
+    await previewAllButtons[1].trigger("click");
     await nextTick();
 
     const applyButton = wrapper
       .findAll("button")
-      .find((button) => button.text().includes("Apply previewed orphan deletion"));
+      .find((button) =>
+        button.text().includes("Apply `.fuse_hidden*` preview"),
+      );
     expect((applyButton!.element as HTMLButtonElement).disabled).toBe(true);
 
     const confirmations = wrapper.findAll(".catalog-remediation-confirm input");
-    await confirmations[2].setValue(true);
-    await confirmations[3].setValue(true);
+    await confirmations[confirmations.length - 2].setValue(true);
+    await confirmations[confirmations.length - 1].setValue(true);
     await nextTick();
 
     expect((applyButton!.element as HTMLButtonElement).disabled).toBe(false);

--- a/ui/frontend/src/components/consistency/CatalogRemediationPanel.spec.ts
+++ b/ui/frontend/src/components/consistency/CatalogRemediationPanel.spec.ts
@@ -1,0 +1,158 @@
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CatalogRemediationPanel from "./CatalogRemediationPanel.vue";
+
+function createStore(): any {
+  return {
+    remediationScanResult: {
+      summary: "Catalog remediation findings loaded.",
+    },
+    remediationError: null,
+    remediationPreviewError: null,
+    remediationApplyError: null,
+    brokenDbOriginals: [
+      {
+        finding_id: "broken-1",
+        asset_id: "asset-1",
+        asset_name: "missing.jpg",
+        asset_type: "image",
+        expected_database_path: "/usr/src/app/upload/upload/user-a/missing.jpg",
+        expected_relative_path: "user-a/missing.jpg",
+        classification: "missing_confirmed",
+        action_eligible: true,
+        action_reason: "Eligible",
+        found_absolute_path: null,
+        message: "Missing confirmed.",
+      },
+      {
+        finding_id: "broken-2",
+        asset_id: "asset-2",
+        asset_name: "relocated.jpg",
+        asset_type: "image",
+        expected_database_path: "/usr/src/app/upload/upload/user-a/relocated.jpg",
+        expected_relative_path: "user-a/relocated.jpg",
+        classification: "found_elsewhere",
+        action_eligible: false,
+        action_reason: "Inspect only",
+        found_absolute_path: "/upload/user-b/relocated.jpg",
+        message: "Found elsewhere.",
+      },
+    ],
+    fuseHiddenOrphans: [
+      {
+        finding_id: "fuse-1",
+        root_slug: "uploads",
+        relative_path: "user-a/.fuse_hidden0001",
+        absolute_path: "/upload/user-a/.fuse_hidden0001",
+        file_name: ".fuse_hidden0001",
+        size_bytes: 123,
+        classification: "blocked_in_use",
+        action_eligible: false,
+        action_reason: "Blocked",
+        message: "Still in use.",
+      },
+      {
+        finding_id: "fuse-2",
+        root_slug: "uploads",
+        relative_path: "user-b/.fuse_hidden0002",
+        absolute_path: "/upload/user-b/.fuse_hidden0002",
+        file_name: ".fuse_hidden0002",
+        size_bytes: 456,
+        classification: "deletable_orphan",
+        action_eligible: true,
+        action_reason: "Eligible",
+        message: "Safe to delete.",
+      },
+    ],
+    isLoadingRemediation: false,
+    isPreviewing: false,
+    isApplying: false,
+    loadRemediation: vi.fn().mockResolvedValue(undefined),
+    previewBrokenDbOriginals: vi.fn().mockResolvedValue({
+      summary: "Preview planned 1 remediation item.",
+      repair_run_id: "broken-run",
+    }),
+    previewFuseHidden: vi.fn().mockResolvedValue({
+      summary: "Preview planned 1 remediation item.",
+      repair_run_id: "fuse-run",
+    }),
+    applyRemediation: vi.fn().mockResolvedValue({
+      summary: "Apply processed 1 selected remediation items.",
+    }),
+  };
+}
+
+let store = createStore();
+
+vi.mock("@/stores/consistency", () => ({
+  useConsistencyStore: () => store,
+}));
+
+describe("CatalogRemediationPanel", () => {
+  beforeEach(() => {
+    store = createStore();
+    vi.clearAllMocks();
+  });
+
+  it("previews only eligible broken DB originals and keeps found_elsewhere inspect-only", async () => {
+    const wrapper = mount(CatalogRemediationPanel, {
+      global: {
+        stubs: {
+          StatusTag: { template: "<span>{{ status }}</span>", props: ["status"] },
+        },
+      },
+    });
+    await nextTick();
+
+    const brokenCheckboxes = wrapper.findAll("tbody input[type='checkbox']");
+    expect((brokenCheckboxes[1].element as HTMLInputElement).disabled).toBe(true);
+
+    await brokenCheckboxes[0].setValue(true);
+    await nextTick();
+
+    const previewButton = wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Preview selected (1)"));
+    await previewButton!.trigger("click");
+    await nextTick();
+
+    expect(store.previewBrokenDbOriginals).toHaveBeenCalledWith({
+      asset_ids: ["asset-1"],
+      select_all: false,
+    });
+  });
+
+  it("requires both confirmation checkboxes before apply for fuse-hidden deletion", async () => {
+    const wrapper = mount(CatalogRemediationPanel, {
+      global: {
+        stubs: {
+          StatusTag: { template: "<span>{{ status }}</span>", props: ["status"] },
+        },
+      },
+    });
+    await nextTick();
+
+    const previewAllFuseButton = wrapper
+      .findAll("button")
+      .filter((button) => button.text().includes("Preview all eligible (1)"))[1];
+    await previewAllFuseButton!.trigger("click");
+    await nextTick();
+
+    const applyButton = wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Apply previewed orphan deletion"));
+    expect((applyButton!.element as HTMLButtonElement).disabled).toBe(true);
+
+    const confirmations = wrapper.findAll(".catalog-remediation-confirm input");
+    await confirmations[2].setValue(true);
+    await confirmations[3].setValue(true);
+    await nextTick();
+
+    expect((applyButton!.element as HTMLButtonElement).disabled).toBe(false);
+    await applyButton!.trigger("click");
+    await nextTick();
+
+    expect(store.applyRemediation).toHaveBeenCalledWith("fuse-run");
+  });
+});

--- a/ui/frontend/src/components/consistency/CatalogRemediationPanel.vue
+++ b/ui/frontend/src/components/consistency/CatalogRemediationPanel.vue
@@ -1,0 +1,429 @@
+<template>
+  <section class="panel catalog-remediation-panel">
+    <div class="settings-section__header">
+      <div>
+        <h3>Catalog-backed remediation review</h3>
+        <p>
+          Review explicit broken DB originals and `.fuse_hidden*` orphan artifacts before any
+          apply step.
+        </p>
+      </div>
+      <StatusTag :status="panelStatus" />
+    </div>
+
+    <p class="health-card__summary">
+      {{ consistencyStore.remediationScanResult?.summary ?? "No remediation findings loaded yet." }}
+    </p>
+    <p v-if="consistencyStore.remediationError" class="runtime-blocking-message">
+      {{ consistencyStore.remediationError }}
+    </p>
+
+    <section class="catalog-remediation-section">
+      <div class="settings-section__header">
+        <div>
+          <h4>Broken DB originals</h4>
+          <p>
+            `missing_confirmed` stays eligible for DB cleanup preview. `found_elsewhere` stays
+            inspect-only by default.
+          </p>
+        </div>
+        <StatusTag :status="brokenDbStatus" />
+      </div>
+
+      <div class="runtime-actions">
+        <button
+          type="button"
+          class="runtime-action runtime-action--secondary"
+          :disabled="consistencyStore.isLoadingRemediation"
+          @click="void refreshPanel()"
+        >
+          {{ consistencyStore.isLoadingRemediation ? "Refreshing..." : "Refresh findings" }}
+        </button>
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="!selectedBrokenEligible.length || consistencyStore.isPreviewing"
+          @click="void previewBrokenSelected()"
+        >
+          Preview selected ({{ selectedBrokenEligible.length }})
+        </button>
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="!brokenEligibleFindings.length || consistencyStore.isPreviewing"
+          @click="void previewBrokenAll()"
+        >
+          Preview all eligible ({{ brokenEligibleFindings.length }})
+        </button>
+      </div>
+
+      <div class="catalog-remediation-table-wrapper">
+        <table class="catalog-table">
+          <thead>
+            <tr>
+              <th>
+                <input
+                  type="checkbox"
+                  :checked="allBrokenVisibleSelected"
+                  :disabled="!brokenEligibleFindings.length"
+                  @change="toggleAllBroken(($event.target as HTMLInputElement).checked)"
+                />
+              </th>
+              <th>Asset</th>
+              <th>Classification</th>
+              <th>Expected path</th>
+              <th>Found path</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="finding in consistencyStore.brokenDbOriginals" :key="finding.finding_id">
+              <td>
+                <input
+                  type="checkbox"
+                  :checked="selectedBrokenIds.includes(finding.asset_id)"
+                  :disabled="!finding.action_eligible"
+                  @change="toggleBroken(finding.asset_id, ($event.target as HTMLInputElement).checked)"
+                />
+              </td>
+              <td>
+                <strong>{{ finding.asset_name ?? finding.asset_id }}</strong>
+                <small class="catalog-remediation-muted">{{ finding.asset_id }}</small>
+              </td>
+              <td>
+                <span :class="badgeClass(finding.classification)" class="consistency-chip">
+                  {{ finding.classification }}
+                </span>
+                <small class="catalog-remediation-muted">{{ finding.message }}</small>
+              </td>
+              <td class="catalog-remediation-mono">{{ finding.expected_database_path }}</td>
+              <td class="catalog-remediation-mono">
+                {{ finding.found_absolute_path ?? "No alternate path found" }}
+              </td>
+              <td>{{ finding.action_reason }}</td>
+            </tr>
+            <tr v-if="!consistencyStore.brokenDbOriginals.length">
+              <td colspan="6" class="consistency-empty-row">No broken DB originals found.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="catalog-remediation-preview">
+        <p class="health-card__details">{{ brokenPreview?.summary ?? "No preview prepared." }}</p>
+        <p v-if="consistencyStore.remediationPreviewError" class="runtime-blocking-message">
+          {{ consistencyStore.remediationPreviewError }}
+        </p>
+        <p v-if="brokenApplyResult" class="health-card__details">{{ brokenApplyResult.summary }}</p>
+        <div class="catalog-remediation-confirm">
+          <label><input v-model="brokenWarningRead" type="checkbox" /> I reviewed the preview.</label>
+          <label><input v-model="brokenBackupRead" type="checkbox" /> I understand DB cleanup is destructive.</label>
+        </div>
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="brokenApplyDisabled"
+          @click="void applyBrokenPreview()"
+        >
+          Apply previewed DB cleanup
+        </button>
+      </div>
+    </section>
+
+    <section class="catalog-remediation-section">
+      <div class="settings-section__header">
+        <div>
+          <h4>`.fuse_hidden*` storage orphans</h4>
+          <p>
+            `.immich` stays ignored. Only `deletable_orphan` rows become eligible for explicit
+            delete apply.
+          </p>
+        </div>
+        <StatusTag :status="fuseStatus" />
+      </div>
+
+      <div class="runtime-actions">
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="!selectedFuseEligible.length || consistencyStore.isPreviewing"
+          @click="void previewFuseSelected()"
+        >
+          Preview selected ({{ selectedFuseEligible.length }})
+        </button>
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="!fuseEligibleFindings.length || consistencyStore.isPreviewing"
+          @click="void previewFuseAll()"
+        >
+          Preview all eligible ({{ fuseEligibleFindings.length }})
+        </button>
+      </div>
+
+      <div class="catalog-remediation-table-wrapper">
+        <table class="catalog-table">
+          <thead>
+            <tr>
+              <th>
+                <input
+                  type="checkbox"
+                  :checked="allFuseVisibleSelected"
+                  :disabled="!fuseEligibleFindings.length"
+                  @change="toggleAllFuse(($event.target as HTMLInputElement).checked)"
+                />
+              </th>
+              <th>File</th>
+              <th>Classification</th>
+              <th>Path</th>
+              <th>Size</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="finding in consistencyStore.fuseHiddenOrphans" :key="finding.finding_id">
+              <td>
+                <input
+                  type="checkbox"
+                  :checked="selectedFuseIds.includes(finding.finding_id)"
+                  :disabled="!finding.action_eligible"
+                  @change="toggleFuse(finding.finding_id, ($event.target as HTMLInputElement).checked)"
+                />
+              </td>
+              <td>
+                <strong>{{ finding.file_name }}</strong>
+                <small class="catalog-remediation-muted">{{ finding.root_slug }}</small>
+              </td>
+              <td>
+                <span :class="badgeClass(finding.classification)" class="consistency-chip">
+                  {{ finding.classification }}
+                </span>
+                <small class="catalog-remediation-muted">{{ finding.message }}</small>
+              </td>
+              <td class="catalog-remediation-mono">{{ finding.absolute_path }}</td>
+              <td>{{ finding.size_bytes }}</td>
+              <td>{{ finding.action_reason }}</td>
+            </tr>
+            <tr v-if="!consistencyStore.fuseHiddenOrphans.length">
+              <td colspan="6" class="consistency-empty-row">No `.fuse_hidden*` orphan artifacts found.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="catalog-remediation-preview">
+        <p class="health-card__details">{{ fusePreview?.summary ?? "No preview prepared." }}</p>
+        <p v-if="consistencyStore.remediationApplyError" class="runtime-blocking-message">
+          {{ consistencyStore.remediationApplyError }}
+        </p>
+        <p v-if="fuseApplyResult" class="health-card__details">{{ fuseApplyResult.summary }}</p>
+        <div class="catalog-remediation-confirm">
+          <label><input v-model="fuseWarningRead" type="checkbox" /> I reviewed the preview.</label>
+          <label><input v-model="fuseDeleteRead" type="checkbox" /> I understand deletion is irreversible here.</label>
+        </div>
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="fuseApplyDisabled"
+          @click="void applyFusePreview()"
+        >
+          Apply previewed orphan deletion
+        </button>
+      </div>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import StatusTag from "@/components/common/StatusTag.vue";
+import { useConsistencyStore } from "@/stores/consistency";
+import type {
+  CatalogRemediationApplyResponse,
+  CatalogRemediationPreviewResponse,
+} from "@/api/types/consistency";
+
+type HealthTag = "ok" | "warning" | "error" | "unknown";
+
+const consistencyStore = useConsistencyStore();
+const selectedBrokenIds = ref<string[]>([]);
+const selectedFuseIds = ref<string[]>([]);
+const brokenPreview = ref<CatalogRemediationPreviewResponse | null>(null);
+const fusePreview = ref<CatalogRemediationPreviewResponse | null>(null);
+const brokenApplyResult = ref<CatalogRemediationApplyResponse | null>(null);
+const fuseApplyResult = ref<CatalogRemediationApplyResponse | null>(null);
+const brokenWarningRead = ref(false);
+const brokenBackupRead = ref(false);
+const fuseWarningRead = ref(false);
+const fuseDeleteRead = ref(false);
+
+const brokenEligibleFindings = computed(() =>
+  consistencyStore.brokenDbOriginals.filter((finding) => finding.action_eligible),
+);
+const fuseEligibleFindings = computed(() =>
+  consistencyStore.fuseHiddenOrphans.filter((finding) => finding.action_eligible),
+);
+const selectedBrokenEligible = computed(() =>
+  brokenEligibleFindings.value.filter((finding) => selectedBrokenIds.value.includes(finding.asset_id)),
+);
+const selectedFuseEligible = computed(() =>
+  fuseEligibleFindings.value.filter((finding) => selectedFuseIds.value.includes(finding.finding_id)),
+);
+const allBrokenVisibleSelected = computed(
+  () =>
+    Boolean(brokenEligibleFindings.value.length) &&
+    selectedBrokenEligible.value.length === brokenEligibleFindings.value.length,
+);
+const allFuseVisibleSelected = computed(
+  () =>
+    Boolean(fuseEligibleFindings.value.length) &&
+    selectedFuseEligible.value.length === fuseEligibleFindings.value.length,
+);
+const brokenApplyDisabled = computed(
+  () => !brokenPreview.value || !brokenWarningRead.value || !brokenBackupRead.value || consistencyStore.isApplying,
+);
+const fuseApplyDisabled = computed(
+  () => !fusePreview.value || !fuseWarningRead.value || !fuseDeleteRead.value || consistencyStore.isApplying,
+);
+const panelStatus = computed<HealthTag>(() => {
+  if (consistencyStore.remediationError) {
+    return "error";
+  }
+  if (consistencyStore.brokenDbOriginals.length || consistencyStore.fuseHiddenOrphans.length) {
+    return "warning";
+  }
+  return "ok";
+});
+const brokenDbStatus = computed<HealthTag>(() =>
+  consistencyStore.brokenDbOriginals.length ? "warning" : "ok",
+);
+const fuseStatus = computed<HealthTag>(() =>
+  consistencyStore.fuseHiddenOrphans.length ? "warning" : "ok",
+);
+
+function badgeClass(value: string): string {
+  return `consistency-chip--finding-${value}`;
+}
+
+function toggleBroken(assetId: string, checked: boolean): void {
+  selectedBrokenIds.value = checked
+    ? [...new Set([...selectedBrokenIds.value, assetId])]
+    : selectedBrokenIds.value.filter((item) => item !== assetId);
+}
+
+function toggleFuse(findingId: string, checked: boolean): void {
+  selectedFuseIds.value = checked
+    ? [...new Set([...selectedFuseIds.value, findingId])]
+    : selectedFuseIds.value.filter((item) => item !== findingId);
+}
+
+function toggleAllBroken(checked: boolean): void {
+  selectedBrokenIds.value = checked ? brokenEligibleFindings.value.map((item) => item.asset_id) : [];
+}
+
+function toggleAllFuse(checked: boolean): void {
+  selectedFuseIds.value = checked ? fuseEligibleFindings.value.map((item) => item.finding_id) : [];
+}
+
+async function refreshPanel(): Promise<void> {
+  await consistencyStore.loadRemediation();
+}
+
+async function previewBrokenSelected(): Promise<void> {
+  const result = await consistencyStore.previewBrokenDbOriginals({
+    asset_ids: selectedBrokenEligible.value.map((item) => item.asset_id),
+    select_all: false,
+  });
+  if (result) {
+    brokenPreview.value = result;
+    brokenApplyResult.value = null;
+    brokenWarningRead.value = false;
+    brokenBackupRead.value = false;
+  }
+}
+
+async function previewBrokenAll(): Promise<void> {
+  const result = await consistencyStore.previewBrokenDbOriginals({ asset_ids: [], select_all: true });
+  if (result) {
+    brokenPreview.value = result;
+    brokenApplyResult.value = null;
+    brokenWarningRead.value = false;
+    brokenBackupRead.value = false;
+    selectedBrokenIds.value = brokenEligibleFindings.value.map((item) => item.asset_id);
+  }
+}
+
+async function applyBrokenPreview(): Promise<void> {
+  if (!brokenPreview.value) {
+    return;
+  }
+  const result = await consistencyStore.applyRemediation(brokenPreview.value.repair_run_id);
+  if (result) {
+    brokenApplyResult.value = result;
+    brokenPreview.value = null;
+  }
+}
+
+async function previewFuseSelected(): Promise<void> {
+  const result = await consistencyStore.previewFuseHidden({
+    finding_ids: selectedFuseEligible.value.map((item) => item.finding_id),
+    select_all: false,
+  });
+  if (result) {
+    fusePreview.value = result;
+    fuseApplyResult.value = null;
+    fuseWarningRead.value = false;
+    fuseDeleteRead.value = false;
+  }
+}
+
+async function previewFuseAll(): Promise<void> {
+  const result = await consistencyStore.previewFuseHidden({ finding_ids: [], select_all: true });
+  if (result) {
+    fusePreview.value = result;
+    fuseApplyResult.value = null;
+    fuseWarningRead.value = false;
+    fuseDeleteRead.value = false;
+    selectedFuseIds.value = fuseEligibleFindings.value.map((item) => item.finding_id);
+  }
+}
+
+async function applyFusePreview(): Promise<void> {
+  if (!fusePreview.value) {
+    return;
+  }
+  const result = await consistencyStore.applyRemediation(fusePreview.value.repair_run_id);
+  if (result) {
+    fuseApplyResult.value = result;
+    fusePreview.value = null;
+  }
+}
+</script>
+
+<style scoped>
+.catalog-remediation-panel,
+.catalog-remediation-section,
+.catalog-remediation-preview {
+  display: grid;
+  gap: 1rem;
+}
+
+.catalog-remediation-table-wrapper {
+  overflow-x: auto;
+}
+
+.catalog-remediation-confirm {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.catalog-remediation-muted {
+  display: block;
+  color: #5c6b77;
+}
+
+.catalog-remediation-mono {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  word-break: break-all;
+}
+</style>

--- a/ui/frontend/src/components/consistency/CatalogRemediationPanel.vue
+++ b/ui/frontend/src/components/consistency/CatalogRemediationPanel.vue
@@ -4,27 +4,48 @@
       <div>
         <h3>Catalog-backed remediation review</h3>
         <p>
-          Review explicit broken DB originals and `.fuse_hidden*` orphan artifacts before any
-          apply step.
+          Review broken DB originals, zero-byte files, and `.fuse_hidden*`
+          storage artifacts before any explicit apply step.
         </p>
       </div>
       <StatusTag :status="panelStatus" />
     </div>
 
     <p class="health-card__summary">
-      {{ consistencyStore.remediationScanResult?.summary ?? "No remediation findings loaded yet." }}
+      {{
+        consistencyStore.remediationScanResult?.summary ??
+        "No remediation findings loaded yet."
+      }}
     </p>
-    <p v-if="consistencyStore.remediationError" class="runtime-blocking-message">
+    <p
+      v-if="consistencyStore.remediationError"
+      class="runtime-blocking-message"
+    >
       {{ consistencyStore.remediationError }}
     </p>
+
+    <div class="runtime-actions">
+      <button
+        type="button"
+        class="runtime-action runtime-action--secondary"
+        :disabled="consistencyStore.isLoadingRemediation"
+        @click="void refreshPanel()"
+      >
+        {{
+          consistencyStore.isLoadingRemediation
+            ? "Refreshing..."
+            : "Refresh findings"
+        }}
+      </button>
+    </div>
 
     <section class="catalog-remediation-section">
       <div class="settings-section__header">
         <div>
           <h4>Broken DB originals</h4>
           <p>
-            `missing_confirmed` stays eligible for DB cleanup preview. `found_elsewhere` stays
-            inspect-only by default.
+            `missing_confirmed` can use DB cleanup. `found_with_hash_match` can
+            use explicit path correction. `found_elsewhere` stays inspect-only.
           </p>
         </div>
         <StatusTag :status="brokenDbStatus" />
@@ -33,27 +54,42 @@
       <div class="runtime-actions">
         <button
           type="button"
-          class="runtime-action runtime-action--secondary"
-          :disabled="consistencyStore.isLoadingRemediation"
-          @click="void refreshPanel()"
+          class="runtime-action"
+          :disabled="
+            !selectedBrokenCleanupEligible.length ||
+            consistencyStore.isPreviewing
+          "
+          @click="void previewBrokenCleanupSelected()"
         >
-          {{ consistencyStore.isLoadingRemediation ? "Refreshing..." : "Refresh findings" }}
+          Preview cleanup selected ({{ selectedBrokenCleanupEligible.length }})
         </button>
         <button
           type="button"
           class="runtime-action"
-          :disabled="!selectedBrokenEligible.length || consistencyStore.isPreviewing"
-          @click="void previewBrokenSelected()"
+          :disabled="
+            !brokenCleanupEligible.length || consistencyStore.isPreviewing
+          "
+          @click="void previewBrokenCleanupAll()"
         >
-          Preview selected ({{ selectedBrokenEligible.length }})
+          Preview cleanup all eligible ({{ brokenCleanupEligible.length }})
         </button>
         <button
           type="button"
           class="runtime-action"
-          :disabled="!brokenEligibleFindings.length || consistencyStore.isPreviewing"
-          @click="void previewBrokenAll()"
+          :disabled="
+            !selectedBrokenFixEligible.length || consistencyStore.isPreviewing
+          "
+          @click="void previewBrokenFixSelected()"
         >
-          Preview all eligible ({{ brokenEligibleFindings.length }})
+          Preview path fix selected ({{ selectedBrokenFixEligible.length }})
+        </button>
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="!brokenFixEligible.length || consistencyStore.isPreviewing"
+          @click="void previewBrokenFixAll()"
+        >
+          Preview path fix all eligible ({{ brokenFixEligible.length }})
         </button>
       </div>
 
@@ -65,59 +101,106 @@
                 <input
                   type="checkbox"
                   :checked="allBrokenVisibleSelected"
-                  :disabled="!brokenEligibleFindings.length"
-                  @change="toggleAllBroken(($event.target as HTMLInputElement).checked)"
+                  :disabled="!brokenSelectableFindings.length"
+                  @change="
+                    toggleAllBroken(($event.target as HTMLInputElement).checked)
+                  "
                 />
               </th>
               <th>Asset</th>
               <th>Classification</th>
               <th>Expected path</th>
               <th>Found path</th>
+              <th>Verification</th>
               <th>Action</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="finding in consistencyStore.brokenDbOriginals" :key="finding.finding_id">
+            <tr
+              v-for="finding in consistencyStore.brokenDbOriginals"
+              :key="finding.finding_id"
+            >
               <td>
                 <input
                   type="checkbox"
                   :checked="selectedBrokenIds.includes(finding.asset_id)"
                   :disabled="!finding.action_eligible"
-                  @change="toggleBroken(finding.asset_id, ($event.target as HTMLInputElement).checked)"
+                  @change="
+                    toggleBroken(
+                      finding.asset_id,
+                      ($event.target as HTMLInputElement).checked,
+                    )
+                  "
                 />
               </td>
               <td>
                 <strong>{{ finding.asset_name ?? finding.asset_id }}</strong>
-                <small class="catalog-remediation-muted">{{ finding.asset_id }}</small>
+                <small class="catalog-remediation-muted">{{
+                  finding.asset_id
+                }}</small>
               </td>
               <td>
-                <span :class="badgeClass(finding.classification)" class="consistency-chip">
+                <span
+                  :class="badgeClass(finding.classification)"
+                  class="consistency-chip"
+                >
                   {{ finding.classification }}
                 </span>
-                <small class="catalog-remediation-muted">{{ finding.message }}</small>
+                <small class="catalog-remediation-muted">{{
+                  finding.message
+                }}</small>
               </td>
-              <td class="catalog-remediation-mono">{{ finding.expected_database_path }}</td>
               <td class="catalog-remediation-mono">
-                {{ finding.found_absolute_path ?? "No alternate path found" }}
+                {{ finding.expected_database_path }}
+              </td>
+              <td class="catalog-remediation-mono">
+                {{ finding.found_absolute_path ?? "Not found" }}
+              </td>
+              <td>
+                <span v-if="finding.checksum_match === true"
+                  >Hash match verified</span
+                >
+                <span v-else-if="finding.checksum_match === false"
+                  >Hash mismatch</span
+                >
+                <span v-else-if="finding.checksum_value"
+                  >Checksum unavailable for safe auto-verify</span
+                >
+                <span v-else>Size/path only</span>
               </td>
               <td>{{ finding.action_reason }}</td>
             </tr>
             <tr v-if="!consistencyStore.brokenDbOriginals.length">
-              <td colspan="6" class="consistency-empty-row">No broken DB originals found.</td>
+              <td colspan="7" class="consistency-empty-row">
+                No broken DB originals found.
+              </td>
             </tr>
           </tbody>
         </table>
       </div>
 
       <div class="catalog-remediation-preview">
-        <p class="health-card__details">{{ brokenPreview?.summary ?? "No preview prepared." }}</p>
-        <p v-if="consistencyStore.remediationPreviewError" class="runtime-blocking-message">
+        <p class="health-card__details">
+          {{ brokenPreview?.summary ?? "No broken DB preview prepared." }}
+        </p>
+        <p
+          v-if="consistencyStore.remediationPreviewError"
+          class="runtime-blocking-message"
+        >
           {{ consistencyStore.remediationPreviewError }}
         </p>
-        <p v-if="brokenApplyResult" class="health-card__details">{{ brokenApplyResult.summary }}</p>
+        <p v-if="brokenApplyResult" class="health-card__details">
+          {{ brokenApplyResult.summary }}
+        </p>
         <div class="catalog-remediation-confirm">
-          <label><input v-model="brokenWarningRead" type="checkbox" /> I reviewed the preview.</label>
-          <label><input v-model="brokenBackupRead" type="checkbox" /> I understand DB cleanup is destructive.</label>
+          <label
+            ><input v-model="brokenWarningRead" type="checkbox" /> I reviewed
+            the preview.</label
+          >
+          <label>
+            <input v-model="brokenMutationRead" type="checkbox" />
+            I understand this apply step mutates DB state.
+          </label>
         </div>
         <button
           type="button"
@@ -125,7 +208,146 @@
           :disabled="brokenApplyDisabled"
           @click="void applyBrokenPreview()"
         >
-          Apply previewed DB cleanup
+          Apply broken DB preview
+        </button>
+      </div>
+    </section>
+
+    <section class="catalog-remediation-section">
+      <div class="settings-section__header">
+        <div>
+          <h4>Zero-byte files</h4>
+          <p>
+            Upload orphans and broken derivatives can be deleted explicitly.
+            Zero-byte uploads that are still referenced as originals remain
+            blocked.
+          </p>
+        </div>
+        <StatusTag :status="zeroByteStatus" />
+      </div>
+
+      <div class="runtime-actions">
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="
+            !selectedZeroByteEligible.length || consistencyStore.isPreviewing
+          "
+          @click="void previewZeroByteSelected()"
+        >
+          Preview selected ({{ selectedZeroByteEligible.length }})
+        </button>
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="
+            !zeroByteEligibleFindings.length || consistencyStore.isPreviewing
+          "
+          @click="void previewZeroByteAll()"
+        >
+          Preview all eligible ({{ zeroByteEligibleFindings.length }})
+        </button>
+      </div>
+
+      <div class="catalog-remediation-table-wrapper">
+        <table class="catalog-table">
+          <thead>
+            <tr>
+              <th>
+                <input
+                  type="checkbox"
+                  :checked="allZeroByteVisibleSelected"
+                  :disabled="!zeroByteEligibleFindings.length"
+                  @change="
+                    toggleAllZeroByte(
+                      ($event.target as HTMLInputElement).checked,
+                    )
+                  "
+                />
+              </th>
+              <th>File</th>
+              <th>Classification</th>
+              <th>Path</th>
+              <th>Asset</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="finding in consistencyStore.zeroByteFindings"
+              :key="finding.finding_id"
+            >
+              <td>
+                <input
+                  type="checkbox"
+                  :checked="selectedZeroByteIds.includes(finding.finding_id)"
+                  :disabled="!finding.action_eligible"
+                  @change="
+                    toggleZeroByte(
+                      finding.finding_id,
+                      ($event.target as HTMLInputElement).checked,
+                    )
+                  "
+                />
+              </td>
+              <td>
+                <strong>{{ finding.file_name }}</strong>
+                <small class="catalog-remediation-muted">{{
+                  finding.root_slug
+                }}</small>
+              </td>
+              <td>
+                <span
+                  :class="badgeClass(finding.classification)"
+                  class="consistency-chip"
+                >
+                  {{ finding.classification }}
+                </span>
+                <small class="catalog-remediation-muted">{{
+                  finding.message
+                }}</small>
+              </td>
+              <td class="catalog-remediation-mono">
+                {{ finding.absolute_path }}
+              </td>
+              <td>
+                {{ finding.asset_name ?? finding.asset_id ?? "No DB asset" }}
+              </td>
+              <td>{{ finding.action_reason }}</td>
+            </tr>
+            <tr v-if="!consistencyStore.zeroByteFindings.length">
+              <td colspan="6" class="consistency-empty-row">
+                No zero-byte remediation findings found.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="catalog-remediation-preview">
+        <p class="health-card__details">
+          {{ zeroBytePreview?.summary ?? "No zero-byte preview prepared." }}
+        </p>
+        <p v-if="zeroByteApplyResult" class="health-card__details">
+          {{ zeroByteApplyResult.summary }}
+        </p>
+        <div class="catalog-remediation-confirm">
+          <label
+            ><input v-model="zeroByteWarningRead" type="checkbox" /> I reviewed
+            the preview.</label
+          >
+          <label>
+            <input v-model="zeroByteDeleteRead" type="checkbox" />
+            I understand deletion is explicit and irreversible here.
+          </label>
+        </div>
+        <button
+          type="button"
+          class="runtime-action"
+          :disabled="zeroByteApplyDisabled"
+          @click="void applyZeroBytePreview()"
+        >
+          Apply zero-byte preview
         </button>
       </div>
     </section>
@@ -135,8 +357,8 @@
         <div>
           <h4>`.fuse_hidden*` storage orphans</h4>
           <p>
-            `.immich` stays ignored. Only `deletable_orphan` rows become eligible for explicit
-            delete apply.
+            `.immich` stays ignored. `blocked_in_use` stays informational. Only
+            `deletable_orphan` rows become eligible for explicit deletion.
           </p>
         </div>
         <StatusTag :status="fuseStatus" />
@@ -146,7 +368,9 @@
         <button
           type="button"
           class="runtime-action"
-          :disabled="!selectedFuseEligible.length || consistencyStore.isPreviewing"
+          :disabled="
+            !selectedFuseEligible.length || consistencyStore.isPreviewing
+          "
           @click="void previewFuseSelected()"
         >
           Preview selected ({{ selectedFuseEligible.length }})
@@ -154,7 +378,9 @@
         <button
           type="button"
           class="runtime-action"
-          :disabled="!fuseEligibleFindings.length || consistencyStore.isPreviewing"
+          :disabled="
+            !fuseEligibleFindings.length || consistencyStore.isPreviewing
+          "
           @click="void previewFuseAll()"
         >
           Preview all eligible ({{ fuseEligibleFindings.length }})
@@ -170,7 +396,9 @@
                   type="checkbox"
                   :checked="allFuseVisibleSelected"
                   :disabled="!fuseEligibleFindings.length"
-                  @change="toggleAllFuse(($event.target as HTMLInputElement).checked)"
+                  @change="
+                    toggleAllFuse(($event.target as HTMLInputElement).checked)
+                  "
                 />
               </th>
               <th>File</th>
@@ -181,45 +409,77 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="finding in consistencyStore.fuseHiddenOrphans" :key="finding.finding_id">
+            <tr
+              v-for="finding in consistencyStore.fuseHiddenOrphans"
+              :key="finding.finding_id"
+            >
               <td>
                 <input
                   type="checkbox"
                   :checked="selectedFuseIds.includes(finding.finding_id)"
                   :disabled="!finding.action_eligible"
-                  @change="toggleFuse(finding.finding_id, ($event.target as HTMLInputElement).checked)"
+                  @change="
+                    toggleFuse(
+                      finding.finding_id,
+                      ($event.target as HTMLInputElement).checked,
+                    )
+                  "
                 />
               </td>
               <td>
                 <strong>{{ finding.file_name }}</strong>
-                <small class="catalog-remediation-muted">{{ finding.root_slug }}</small>
+                <small class="catalog-remediation-muted">{{
+                  finding.root_slug
+                }}</small>
               </td>
               <td>
-                <span :class="badgeClass(finding.classification)" class="consistency-chip">
+                <span
+                  :class="badgeClass(finding.classification)"
+                  class="consistency-chip"
+                >
                   {{ finding.classification }}
                 </span>
-                <small class="catalog-remediation-muted">{{ finding.message }}</small>
+                <small class="catalog-remediation-muted">{{
+                  finding.message
+                }}</small>
               </td>
-              <td class="catalog-remediation-mono">{{ finding.absolute_path }}</td>
+              <td class="catalog-remediation-mono">
+                {{ finding.absolute_path }}
+              </td>
               <td>{{ finding.size_bytes }}</td>
               <td>{{ finding.action_reason }}</td>
             </tr>
             <tr v-if="!consistencyStore.fuseHiddenOrphans.length">
-              <td colspan="6" class="consistency-empty-row">No `.fuse_hidden*` orphan artifacts found.</td>
+              <td colspan="6" class="consistency-empty-row">
+                No `.fuse_hidden*` orphan artifacts found.
+              </td>
             </tr>
           </tbody>
         </table>
       </div>
 
       <div class="catalog-remediation-preview">
-        <p class="health-card__details">{{ fusePreview?.summary ?? "No preview prepared." }}</p>
-        <p v-if="consistencyStore.remediationApplyError" class="runtime-blocking-message">
+        <p class="health-card__details">
+          {{ fusePreview?.summary ?? "No fuse-hidden preview prepared." }}
+        </p>
+        <p
+          v-if="consistencyStore.remediationApplyError"
+          class="runtime-blocking-message"
+        >
           {{ consistencyStore.remediationApplyError }}
         </p>
-        <p v-if="fuseApplyResult" class="health-card__details">{{ fuseApplyResult.summary }}</p>
+        <p v-if="fuseApplyResult" class="health-card__details">
+          {{ fuseApplyResult.summary }}
+        </p>
         <div class="catalog-remediation-confirm">
-          <label><input v-model="fuseWarningRead" type="checkbox" /> I reviewed the preview.</label>
-          <label><input v-model="fuseDeleteRead" type="checkbox" /> I understand deletion is irreversible here.</label>
+          <label
+            ><input v-model="fuseWarningRead" type="checkbox" /> I reviewed the
+            preview.</label
+          >
+          <label>
+            <input v-model="fuseDeleteRead" type="checkbox" />
+            I understand deletion is irreversible here.
+          </label>
         </div>
         <button
           type="button"
@@ -227,7 +487,7 @@
           :disabled="fuseApplyDisabled"
           @click="void applyFusePreview()"
         >
-          Apply previewed orphan deletion
+          Apply `.fuse_hidden*` preview
         </button>
       </div>
     </section>
@@ -247,32 +507,78 @@ type HealthTag = "ok" | "warning" | "error" | "unknown";
 
 const consistencyStore = useConsistencyStore();
 const selectedBrokenIds = ref<string[]>([]);
+const selectedZeroByteIds = ref<string[]>([]);
 const selectedFuseIds = ref<string[]>([]);
 const brokenPreview = ref<CatalogRemediationPreviewResponse | null>(null);
+const zeroBytePreview = ref<CatalogRemediationPreviewResponse | null>(null);
 const fusePreview = ref<CatalogRemediationPreviewResponse | null>(null);
 const brokenApplyResult = ref<CatalogRemediationApplyResponse | null>(null);
+const zeroByteApplyResult = ref<CatalogRemediationApplyResponse | null>(null);
 const fuseApplyResult = ref<CatalogRemediationApplyResponse | null>(null);
 const brokenWarningRead = ref(false);
-const brokenBackupRead = ref(false);
+const brokenMutationRead = ref(false);
+const zeroByteWarningRead = ref(false);
+const zeroByteDeleteRead = ref(false);
 const fuseWarningRead = ref(false);
 const fuseDeleteRead = ref(false);
 
-const brokenEligibleFindings = computed(() =>
-  consistencyStore.brokenDbOriginals.filter((finding) => finding.action_eligible),
+const brokenCleanupEligible = computed(() =>
+  consistencyStore.brokenDbOriginals.filter((finding) =>
+    finding.eligible_actions.includes("broken_db_cleanup"),
+  ),
+);
+const brokenFixEligible = computed(() =>
+  consistencyStore.brokenDbOriginals.filter((finding) =>
+    finding.eligible_actions.includes("broken_db_path_fix"),
+  ),
+);
+const brokenSelectableFindings = computed(() =>
+  consistencyStore.brokenDbOriginals.filter(
+    (finding) => finding.action_eligible,
+  ),
+);
+const selectedBrokenCleanupEligible = computed(() =>
+  brokenCleanupEligible.value.filter((finding) =>
+    selectedBrokenIds.value.includes(finding.asset_id),
+  ),
+);
+const selectedBrokenFixEligible = computed(() =>
+  brokenFixEligible.value.filter((finding) =>
+    selectedBrokenIds.value.includes(finding.asset_id),
+  ),
+);
+const zeroByteEligibleFindings = computed(() =>
+  consistencyStore.zeroByteFindings.filter(
+    (finding) => finding.action_eligible,
+  ),
+);
+const selectedZeroByteEligible = computed(() =>
+  zeroByteEligibleFindings.value.filter((finding) =>
+    selectedZeroByteIds.value.includes(finding.finding_id),
+  ),
 );
 const fuseEligibleFindings = computed(() =>
-  consistencyStore.fuseHiddenOrphans.filter((finding) => finding.action_eligible),
-);
-const selectedBrokenEligible = computed(() =>
-  brokenEligibleFindings.value.filter((finding) => selectedBrokenIds.value.includes(finding.asset_id)),
+  consistencyStore.fuseHiddenOrphans.filter(
+    (finding) => finding.action_eligible,
+  ),
 );
 const selectedFuseEligible = computed(() =>
-  fuseEligibleFindings.value.filter((finding) => selectedFuseIds.value.includes(finding.finding_id)),
+  fuseEligibleFindings.value.filter((finding) =>
+    selectedFuseIds.value.includes(finding.finding_id),
+  ),
 );
 const allBrokenVisibleSelected = computed(
   () =>
-    Boolean(brokenEligibleFindings.value.length) &&
-    selectedBrokenEligible.value.length === brokenEligibleFindings.value.length,
+    Boolean(brokenSelectableFindings.value.length) &&
+    brokenSelectableFindings.value.every((finding) =>
+      selectedBrokenIds.value.includes(finding.asset_id),
+    ),
+);
+const allZeroByteVisibleSelected = computed(
+  () =>
+    Boolean(zeroByteEligibleFindings.value.length) &&
+    selectedZeroByteEligible.value.length ===
+      zeroByteEligibleFindings.value.length,
 );
 const allFuseVisibleSelected = computed(
   () =>
@@ -280,22 +586,44 @@ const allFuseVisibleSelected = computed(
     selectedFuseEligible.value.length === fuseEligibleFindings.value.length,
 );
 const brokenApplyDisabled = computed(
-  () => !brokenPreview.value || !brokenWarningRead.value || !brokenBackupRead.value || consistencyStore.isApplying,
+  () =>
+    !brokenPreview.value ||
+    !brokenWarningRead.value ||
+    !brokenMutationRead.value ||
+    consistencyStore.isApplying,
+);
+const zeroByteApplyDisabled = computed(
+  () =>
+    !zeroBytePreview.value ||
+    !zeroByteWarningRead.value ||
+    !zeroByteDeleteRead.value ||
+    consistencyStore.isApplying,
 );
 const fuseApplyDisabled = computed(
-  () => !fusePreview.value || !fuseWarningRead.value || !fuseDeleteRead.value || consistencyStore.isApplying,
+  () =>
+    !fusePreview.value ||
+    !fuseWarningRead.value ||
+    !fuseDeleteRead.value ||
+    consistencyStore.isApplying,
 );
 const panelStatus = computed<HealthTag>(() => {
   if (consistencyStore.remediationError) {
     return "error";
   }
-  if (consistencyStore.brokenDbOriginals.length || consistencyStore.fuseHiddenOrphans.length) {
+  if (
+    consistencyStore.brokenDbOriginals.length ||
+    consistencyStore.zeroByteFindings.length ||
+    consistencyStore.fuseHiddenOrphans.length
+  ) {
     return "warning";
   }
   return "ok";
 });
 const brokenDbStatus = computed<HealthTag>(() =>
   consistencyStore.brokenDbOriginals.length ? "warning" : "ok",
+);
+const zeroByteStatus = computed<HealthTag>(() =>
+  consistencyStore.zeroByteFindings.length ? "warning" : "ok",
 );
 const fuseStatus = computed<HealthTag>(() =>
   consistencyStore.fuseHiddenOrphans.length ? "warning" : "ok",
@@ -311,6 +639,12 @@ function toggleBroken(assetId: string, checked: boolean): void {
     : selectedBrokenIds.value.filter((item) => item !== assetId);
 }
 
+function toggleZeroByte(findingId: string, checked: boolean): void {
+  selectedZeroByteIds.value = checked
+    ? [...new Set([...selectedZeroByteIds.value, findingId])]
+    : selectedZeroByteIds.value.filter((item) => item !== findingId);
+}
+
 function toggleFuse(findingId: string, checked: boolean): void {
   selectedFuseIds.value = checked
     ? [...new Set([...selectedFuseIds.value, findingId])]
@@ -318,38 +652,76 @@ function toggleFuse(findingId: string, checked: boolean): void {
 }
 
 function toggleAllBroken(checked: boolean): void {
-  selectedBrokenIds.value = checked ? brokenEligibleFindings.value.map((item) => item.asset_id) : [];
+  selectedBrokenIds.value = checked
+    ? brokenSelectableFindings.value.map((item) => item.asset_id)
+    : [];
+}
+
+function toggleAllZeroByte(checked: boolean): void {
+  selectedZeroByteIds.value = checked
+    ? zeroByteEligibleFindings.value.map((item) => item.finding_id)
+    : [];
 }
 
 function toggleAllFuse(checked: boolean): void {
-  selectedFuseIds.value = checked ? fuseEligibleFindings.value.map((item) => item.finding_id) : [];
+  selectedFuseIds.value = checked
+    ? fuseEligibleFindings.value.map((item) => item.finding_id)
+    : [];
 }
 
 async function refreshPanel(): Promise<void> {
   await consistencyStore.loadRemediation();
 }
 
-async function previewBrokenSelected(): Promise<void> {
+async function previewBrokenCleanupSelected(): Promise<void> {
   const result = await consistencyStore.previewBrokenDbOriginals({
-    asset_ids: selectedBrokenEligible.value.map((item) => item.asset_id),
+    asset_ids: selectedBrokenCleanupEligible.value.map((item) => item.asset_id),
     select_all: false,
   });
   if (result) {
     brokenPreview.value = result;
     brokenApplyResult.value = null;
     brokenWarningRead.value = false;
-    brokenBackupRead.value = false;
+    brokenMutationRead.value = false;
   }
 }
 
-async function previewBrokenAll(): Promise<void> {
-  const result = await consistencyStore.previewBrokenDbOriginals({ asset_ids: [], select_all: true });
+async function previewBrokenCleanupAll(): Promise<void> {
+  const result = await consistencyStore.previewBrokenDbOriginals({
+    asset_ids: [],
+    select_all: true,
+  });
   if (result) {
     brokenPreview.value = result;
     brokenApplyResult.value = null;
     brokenWarningRead.value = false;
-    brokenBackupRead.value = false;
-    selectedBrokenIds.value = brokenEligibleFindings.value.map((item) => item.asset_id);
+    brokenMutationRead.value = false;
+  }
+}
+
+async function previewBrokenFixSelected(): Promise<void> {
+  const result = await consistencyStore.previewBrokenDbPathFix({
+    asset_ids: selectedBrokenFixEligible.value.map((item) => item.asset_id),
+    select_all: false,
+  });
+  if (result) {
+    brokenPreview.value = result;
+    brokenApplyResult.value = null;
+    brokenWarningRead.value = false;
+    brokenMutationRead.value = false;
+  }
+}
+
+async function previewBrokenFixAll(): Promise<void> {
+  const result = await consistencyStore.previewBrokenDbPathFix({
+    asset_ids: [],
+    select_all: true,
+  });
+  if (result) {
+    brokenPreview.value = result;
+    brokenApplyResult.value = null;
+    brokenWarningRead.value = false;
+    brokenMutationRead.value = false;
   }
 }
 
@@ -357,10 +729,51 @@ async function applyBrokenPreview(): Promise<void> {
   if (!brokenPreview.value) {
     return;
   }
-  const result = await consistencyStore.applyRemediation(brokenPreview.value.repair_run_id);
+  const result = await consistencyStore.applyRemediation(
+    brokenPreview.value.repair_run_id,
+  );
   if (result) {
     brokenApplyResult.value = result;
     brokenPreview.value = null;
+  }
+}
+
+async function previewZeroByteSelected(): Promise<void> {
+  const result = await consistencyStore.previewZeroByte({
+    finding_ids: selectedZeroByteEligible.value.map((item) => item.finding_id),
+    select_all: false,
+  });
+  if (result) {
+    zeroBytePreview.value = result;
+    zeroByteApplyResult.value = null;
+    zeroByteWarningRead.value = false;
+    zeroByteDeleteRead.value = false;
+  }
+}
+
+async function previewZeroByteAll(): Promise<void> {
+  const result = await consistencyStore.previewZeroByte({
+    finding_ids: [],
+    select_all: true,
+  });
+  if (result) {
+    zeroBytePreview.value = result;
+    zeroByteApplyResult.value = null;
+    zeroByteWarningRead.value = false;
+    zeroByteDeleteRead.value = false;
+  }
+}
+
+async function applyZeroBytePreview(): Promise<void> {
+  if (!zeroBytePreview.value) {
+    return;
+  }
+  const result = await consistencyStore.applyRemediation(
+    zeroBytePreview.value.repair_run_id,
+  );
+  if (result) {
+    zeroByteApplyResult.value = result;
+    zeroBytePreview.value = null;
   }
 }
 
@@ -378,13 +791,15 @@ async function previewFuseSelected(): Promise<void> {
 }
 
 async function previewFuseAll(): Promise<void> {
-  const result = await consistencyStore.previewFuseHidden({ finding_ids: [], select_all: true });
+  const result = await consistencyStore.previewFuseHidden({
+    finding_ids: [],
+    select_all: true,
+  });
   if (result) {
     fusePreview.value = result;
     fuseApplyResult.value = null;
     fuseWarningRead.value = false;
     fuseDeleteRead.value = false;
-    selectedFuseIds.value = fuseEligibleFindings.value.map((item) => item.finding_id);
   }
 }
 
@@ -392,7 +807,9 @@ async function applyFusePreview(): Promise<void> {
   if (!fusePreview.value) {
     return;
   }
-  const result = await consistencyStore.applyRemediation(fusePreview.value.repair_run_id);
+  const result = await consistencyStore.applyRemediation(
+    fusePreview.value.repair_run_id,
+  );
   if (result) {
     fuseApplyResult.value = result;
     fusePreview.value = null;

--- a/ui/frontend/src/stores/consistency.ts
+++ b/ui/frontend/src/stores/consistency.ts
@@ -2,17 +2,25 @@ import { computed, ref } from "vue";
 import { defineStore } from "pinia";
 import { ApiClientError } from "@/api/client";
 import {
+  applyCatalogRemediation,
   applyMissingAssetRemovals,
+  fetchCatalogRemediationFindings,
   deleteMissingAssetRestorePoints,
   fetchCatalogConsistencyJob,
   fetchMissingAssetFindings,
   fetchMissingAssetRestorePoints,
+  previewBrokenDbOriginalRemediation,
+  previewFuseHiddenRemediation,
   previewMissingAssetRemovals,
   restoreMissingAssetRestorePoints,
   startCatalogConsistencyJob,
 } from "@/api/consistency";
 import type { CatalogValidationReport, CatalogWorkflowJobRecord } from "@/api/types/catalog";
 import type {
+  CatalogRemediationApplyResponse,
+  CatalogRemediationPreviewRequest,
+  CatalogRemediationPreviewResponse,
+  CatalogRemediationScanResponse,
   MissingAssetApplyResponse,
   MissingAssetPreviewRequest,
   MissingAssetPreviewResponse,
@@ -52,6 +60,9 @@ function catalogRequiresScan(job: CatalogWorkflowJobRecord | null): boolean {
 }
 
 export const useConsistencyStore = defineStore("consistency", () => {
+  const remediationScanResult = ref<CatalogRemediationScanResponse | null>(null);
+  const remediationPreviewResult = ref<CatalogRemediationPreviewResponse | null>(null);
+  const remediationApplyResult = ref<CatalogRemediationApplyResponse | null>(null);
   const scanResult = ref<MissingAssetScanResponse | null>(null);
   const restorePointsResult = ref<MissingAssetRestorePointsResponse | null>(null);
   const catalogJob = ref<CatalogWorkflowJobRecord | null>(null);
@@ -64,6 +75,7 @@ export const useConsistencyStore = defineStore("consistency", () => {
   const isCatalogLoading = ref(false);
   const isCatalogStarting = ref(false);
   const isLoadingRestorePoints = ref(false);
+  const isLoadingRemediation = ref(false);
   const isPreviewing = ref(false);
   const isApplying = ref(false);
   const isRestoring = ref(false);
@@ -71,6 +83,9 @@ export const useConsistencyStore = defineStore("consistency", () => {
 
   const scanError = ref<string | null>(null);
   const catalogJobError = ref<string | null>(null);
+  const remediationError = ref<string | null>(null);
+  const remediationPreviewError = ref<string | null>(null);
+  const remediationApplyError = ref<string | null>(null);
   const restorePointsError = ref<string | null>(null);
   const previewError = ref<string | null>(null);
   const applyError = ref<string | null>(null);
@@ -159,6 +174,7 @@ export const useConsistencyStore = defineStore("consistency", () => {
         scanError.value = null;
       }
       await Promise.allSettled([
+        loadRemediation(),
         loadRestorePoints(),
         shouldSkipMissingAssetScan.value ? Promise.resolve(null) : scan(),
       ]);
@@ -228,6 +244,21 @@ export const useConsistencyStore = defineStore("consistency", () => {
     }
   }
 
+  async function loadRemediation(): Promise<CatalogRemediationScanResponse | null> {
+    isLoadingRemediation.value = true;
+    remediationError.value = null;
+    try {
+      const response = await fetchCatalogRemediationFindings();
+      remediationScanResult.value = response.data;
+      return response.data;
+    } catch (caughtError) {
+      remediationError.value = toErrorMessage(caughtError);
+      return null;
+    } finally {
+      isLoadingRemediation.value = false;
+    }
+  }
+
   async function preview(
     payload: MissingAssetPreviewRequest,
   ): Promise<MissingAssetPreviewResponse | null> {
@@ -258,6 +289,62 @@ export const useConsistencyStore = defineStore("consistency", () => {
       return response.data;
     } catch (caughtError) {
       applyError.value = toErrorMessage(caughtError);
+      return null;
+    } finally {
+      isApplying.value = false;
+    }
+  }
+
+  async function previewBrokenDbOriginals(
+    payload: CatalogRemediationPreviewRequest,
+  ): Promise<CatalogRemediationPreviewResponse | null> {
+    isPreviewing.value = true;
+    remediationPreviewError.value = null;
+    try {
+      const response = await previewBrokenDbOriginalRemediation(payload);
+      remediationPreviewResult.value = response.data;
+      return response.data;
+    } catch (caughtError) {
+      remediationPreviewError.value = toErrorMessage(caughtError);
+      return null;
+    } finally {
+      isPreviewing.value = false;
+    }
+  }
+
+  async function previewFuseHidden(
+    payload: CatalogRemediationPreviewRequest,
+  ): Promise<CatalogRemediationPreviewResponse | null> {
+    isPreviewing.value = true;
+    remediationPreviewError.value = null;
+    try {
+      const response = await previewFuseHiddenRemediation(payload);
+      remediationPreviewResult.value = response.data;
+      return response.data;
+    } catch (caughtError) {
+      remediationPreviewError.value = toErrorMessage(caughtError);
+      return null;
+    } finally {
+      isPreviewing.value = false;
+    }
+  }
+
+  async function applyRemediation(
+    repairRunId: string,
+  ): Promise<CatalogRemediationApplyResponse | null> {
+    if (!repairRunId) {
+      remediationApplyError.value = "A previewed repair run is required before apply.";
+      return null;
+    }
+    isApplying.value = true;
+    remediationApplyError.value = null;
+    try {
+      const response = await applyCatalogRemediation(repairRunId);
+      remediationApplyResult.value = response.data;
+      await Promise.allSettled([loadRemediation(), scan(), loadRestorePoints()]);
+      return response.data;
+    } catch (caughtError) {
+      remediationApplyError.value = toErrorMessage(caughtError);
       return null;
     } finally {
       isApplying.value = false;
@@ -310,12 +397,20 @@ export const useConsistencyStore = defineStore("consistency", () => {
   const findings = computed<MissingAssetReferenceFinding[]>(
     () => scanResult.value?.findings ?? [],
   );
+  const brokenDbOriginals = computed(
+    () => remediationScanResult.value?.broken_db_originals ?? [],
+  );
+  const fuseHiddenOrphans = computed(
+    () => remediationScanResult.value?.fuse_hidden_orphans ?? [],
+  );
   const restorePoints = computed(() => restorePointsResult.value?.items ?? []);
 
   return {
     apply,
+    applyRemediation,
     applyError,
     applyResult,
+    brokenDbOriginals,
     catalogJob,
     catalogJobError,
     catalogReadinessMessage,
@@ -325,12 +420,14 @@ export const useConsistencyStore = defineStore("consistency", () => {
     deleteError,
     deleteResult,
     deleteRestorePoints,
+    fuseHiddenOrphans,
     findings,
     isApplying,
     isCatalogLoading,
     isCatalogStarting,
     isDeletingRestorePoints,
     isLoading,
+    isLoadingRemediation,
     isLoadingRestorePoints,
     isPreviewing,
     isRestoring,
@@ -338,9 +435,18 @@ export const useConsistencyStore = defineStore("consistency", () => {
     isWaitingOnCatalog,
     load,
     loadCatalogJob,
+    loadRemediation,
     loadRestorePoints,
     preview,
+    previewBrokenDbOriginals,
+    previewFuseHidden,
     previewError,
+    remediationApplyError,
+    remediationApplyResult,
+    remediationError,
+    remediationPreviewError,
+    remediationPreviewResult,
+    remediationScanResult,
     restore,
     restoreError,
     restorePoints,

--- a/ui/frontend/src/stores/consistency.ts
+++ b/ui/frontend/src/stores/consistency.ts
@@ -9,13 +9,18 @@ import {
   fetchCatalogConsistencyJob,
   fetchMissingAssetFindings,
   fetchMissingAssetRestorePoints,
+  previewBrokenDbPathFixRemediation,
   previewBrokenDbOriginalRemediation,
   previewFuseHiddenRemediation,
   previewMissingAssetRemovals,
+  previewZeroByteRemediation,
   restoreMissingAssetRestorePoints,
   startCatalogConsistencyJob,
 } from "@/api/consistency";
-import type { CatalogValidationReport, CatalogWorkflowJobRecord } from "@/api/types/catalog";
+import type {
+  CatalogValidationReport,
+  CatalogWorkflowJobRecord,
+} from "@/api/types/catalog";
 import type {
   CatalogRemediationApplyResponse,
   CatalogRemediationPreviewRequest,
@@ -34,7 +39,9 @@ import type {
 } from "@/api/types/consistency";
 
 function toErrorMessage(caughtError: unknown): string {
-  return caughtError instanceof ApiClientError ? caughtError.payload.message : "Unknown error.";
+  return caughtError instanceof ApiClientError
+    ? caughtError.payload.message
+    : "Unknown error.";
 }
 
 type CatalogReadinessState =
@@ -45,13 +52,17 @@ type CatalogReadinessState =
   | "compare_running"
   | "error";
 
-function catalogBlockedBy(job: CatalogWorkflowJobRecord | null): Record<string, unknown> | null {
+function catalogBlockedBy(
+  job: CatalogWorkflowJobRecord | null,
+): Record<string, unknown> | null {
   const result = job?.result;
   if (!result || typeof result !== "object") {
     return null;
   }
   const blockedBy = result.blockedBy;
-  return blockedBy && typeof blockedBy === "object" ? (blockedBy as Record<string, unknown>) : null;
+  return blockedBy && typeof blockedBy === "object"
+    ? (blockedBy as Record<string, unknown>)
+    : null;
 }
 
 function catalogRequiresScan(job: CatalogWorkflowJobRecord | null): boolean {
@@ -60,11 +71,18 @@ function catalogRequiresScan(job: CatalogWorkflowJobRecord | null): boolean {
 }
 
 export const useConsistencyStore = defineStore("consistency", () => {
-  const remediationScanResult = ref<CatalogRemediationScanResponse | null>(null);
-  const remediationPreviewResult = ref<CatalogRemediationPreviewResponse | null>(null);
-  const remediationApplyResult = ref<CatalogRemediationApplyResponse | null>(null);
+  const remediationScanResult = ref<CatalogRemediationScanResponse | null>(
+    null,
+  );
+  const remediationPreviewResult =
+    ref<CatalogRemediationPreviewResponse | null>(null);
+  const remediationApplyResult = ref<CatalogRemediationApplyResponse | null>(
+    null,
+  );
   const scanResult = ref<MissingAssetScanResponse | null>(null);
-  const restorePointsResult = ref<MissingAssetRestorePointsResponse | null>(null);
+  const restorePointsResult = ref<MissingAssetRestorePointsResponse | null>(
+    null,
+  );
   const catalogJob = ref<CatalogWorkflowJobRecord | null>(null);
   const applyResult = ref<MissingAssetApplyResponse | null>(null);
   const restoreResult = ref<MissingAssetRestoreResponse | null>(null);
@@ -110,14 +128,11 @@ export const useConsistencyStore = defineStore("consistency", () => {
     if (catalogRequiresScan(job)) {
       return "waiting_for_index";
     }
-    const result = job.result && typeof job.result === "object"
-      ? (job.result as Record<string, unknown>)
-      : null;
-    if (
-      job.state === "pending" &&
-      result &&
-      Boolean(result.stale)
-    ) {
+    const result =
+      job.result && typeof job.result === "object"
+        ? (job.result as Record<string, unknown>)
+        : null;
+    if (job.state === "pending" && result && Boolean(result.stale)) {
       return "rebuilding";
     }
     return "ready";
@@ -214,7 +229,9 @@ export const useConsistencyStore = defineStore("consistency", () => {
     }
   }
 
-  async function startCatalog(force = true): Promise<CatalogWorkflowJobRecord | null> {
+  async function startCatalog(
+    force = true,
+  ): Promise<CatalogWorkflowJobRecord | null> {
     isCatalogStarting.value = true;
     catalogJobError.value = null;
     try {
@@ -275,7 +292,9 @@ export const useConsistencyStore = defineStore("consistency", () => {
     }
   }
 
-  async function apply(repairRunId: string): Promise<MissingAssetApplyResponse | null> {
+  async function apply(
+    repairRunId: string,
+  ): Promise<MissingAssetApplyResponse | null> {
     if (!repairRunId) {
       applyError.value = "A previewed repair run is required before apply.";
       return null;
@@ -283,7 +302,9 @@ export const useConsistencyStore = defineStore("consistency", () => {
     isApplying.value = true;
     applyError.value = null;
     try {
-      const response = await applyMissingAssetRemovals({ repair_run_id: repairRunId });
+      const response = await applyMissingAssetRemovals({
+        repair_run_id: repairRunId,
+      });
       applyResult.value = response.data;
       await Promise.allSettled([scan(), loadRestorePoints()]);
       return response.data;
@@ -302,6 +323,40 @@ export const useConsistencyStore = defineStore("consistency", () => {
     remediationPreviewError.value = null;
     try {
       const response = await previewBrokenDbOriginalRemediation(payload);
+      remediationPreviewResult.value = response.data;
+      return response.data;
+    } catch (caughtError) {
+      remediationPreviewError.value = toErrorMessage(caughtError);
+      return null;
+    } finally {
+      isPreviewing.value = false;
+    }
+  }
+
+  async function previewBrokenDbPathFix(
+    payload: CatalogRemediationPreviewRequest,
+  ): Promise<CatalogRemediationPreviewResponse | null> {
+    isPreviewing.value = true;
+    remediationPreviewError.value = null;
+    try {
+      const response = await previewBrokenDbPathFixRemediation(payload);
+      remediationPreviewResult.value = response.data;
+      return response.data;
+    } catch (caughtError) {
+      remediationPreviewError.value = toErrorMessage(caughtError);
+      return null;
+    } finally {
+      isPreviewing.value = false;
+    }
+  }
+
+  async function previewZeroByte(
+    payload: CatalogRemediationPreviewRequest,
+  ): Promise<CatalogRemediationPreviewResponse | null> {
+    isPreviewing.value = true;
+    remediationPreviewError.value = null;
+    try {
+      const response = await previewZeroByteRemediation(payload);
       remediationPreviewResult.value = response.data;
       return response.data;
     } catch (caughtError) {
@@ -333,7 +388,8 @@ export const useConsistencyStore = defineStore("consistency", () => {
     repairRunId: string,
   ): Promise<CatalogRemediationApplyResponse | null> {
     if (!repairRunId) {
-      remediationApplyError.value = "A previewed repair run is required before apply.";
+      remediationApplyError.value =
+        "A previewed repair run is required before apply.";
       return null;
     }
     isApplying.value = true;
@@ -341,7 +397,11 @@ export const useConsistencyStore = defineStore("consistency", () => {
     try {
       const response = await applyCatalogRemediation(repairRunId);
       remediationApplyResult.value = response.data;
-      await Promise.allSettled([loadRemediation(), scan(), loadRestorePoints()]);
+      await Promise.allSettled([
+        loadRemediation(),
+        scan(),
+        loadRestorePoints(),
+      ]);
       return response.data;
     } catch (caughtError) {
       remediationApplyError.value = toErrorMessage(caughtError);
@@ -400,6 +460,9 @@ export const useConsistencyStore = defineStore("consistency", () => {
   const brokenDbOriginals = computed(
     () => remediationScanResult.value?.broken_db_originals ?? [],
   );
+  const zeroByteFindings = computed(
+    () => remediationScanResult.value?.zero_byte_findings ?? [],
+  );
   const fuseHiddenOrphans = computed(
     () => remediationScanResult.value?.fuse_hidden_orphans ?? [],
   );
@@ -438,8 +501,10 @@ export const useConsistencyStore = defineStore("consistency", () => {
     loadRemediation,
     loadRestorePoints,
     preview,
+    previewBrokenDbPathFix,
     previewBrokenDbOriginals,
     previewFuseHidden,
+    previewZeroByte,
     previewError,
     remediationApplyError,
     remediationApplyResult,
@@ -458,5 +523,6 @@ export const useConsistencyStore = defineStore("consistency", () => {
     scanResult,
     shouldSkipMissingAssetScan,
     startCatalog,
+    zeroByteFindings,
   };
 });

--- a/ui/frontend/src/views/consistency/ConsistencyView.spec.ts
+++ b/ui/frontend/src/views/consistency/ConsistencyView.spec.ts
@@ -160,6 +160,11 @@ function createStore(): any {
   return {
     findings,
     restorePoints,
+    brokenDbOriginals: [],
+    fuseHiddenOrphans: [],
+    remediationScanResult: null,
+    remediationPreviewResult: null,
+    remediationApplyResult: null,
     scanResult: {
       domain: "consistency",
       action: "scan",
@@ -202,6 +207,7 @@ function createStore(): any {
     isLoading: false,
     isScanning: false,
     isLoadingRestorePoints: false,
+    isLoadingRemediation: false,
     isPreviewing: false,
     isApplying: false,
     isRestoring: false,
@@ -209,6 +215,9 @@ function createStore(): any {
     isWaitingOnCatalog: false,
     scanError: null,
     catalogJobError: null,
+    remediationError: null,
+    remediationPreviewError: null,
+    remediationApplyError: null,
     restorePointsError: null,
     previewError: null,
     applyError: null,
@@ -218,6 +227,7 @@ function createStore(): any {
     catalogReadinessMessage: "Catalog-backed consistency data is current.",
     load: vi.fn().mockResolvedValue(undefined),
     loadCatalogJob: vi.fn().mockResolvedValue(undefined),
+    loadRemediation: vi.fn().mockResolvedValue(undefined),
     scan: vi.fn().mockResolvedValue(undefined),
     loadRestorePoints: vi.fn().mockResolvedValue(undefined),
     preview: vi.fn(async (payload: { asset_ids: string[]; select_all: boolean }) => {
@@ -230,7 +240,10 @@ function createStore(): any {
       }
       return buildPreviewResponse(selectedFindings, "repair-run-selected", "selected");
     }),
+    previewBrokenDbOriginals: vi.fn().mockResolvedValue(null),
+    previewFuseHidden: vi.fn().mockResolvedValue(null),
     apply: vi.fn(async () => buildApplyResponse("repair-run-all")),
+    applyRemediation: vi.fn().mockResolvedValue(null),
     restore: vi.fn(async () => buildRestoreResponse()),
     deleteRestorePoints: vi.fn(async () => buildDeleteResponse()),
   };
@@ -248,6 +261,7 @@ function mountView() {
       stubs: {
         PageHeader: { template: "<div class='page-header-stub' />" },
         CatalogConsistencyPanel: { template: "<div class='catalog-consistency-panel-stub' />" },
+        CatalogRemediationPanel: { template: "<div class='catalog-remediation-panel-stub' />" },
         DisclaimerBanner: { template: "<div class='disclaimer-stub' />" },
         RiskNotice: { template: "<div class='risk-notice-stub' />", props: ["title", "message"] },
         LoadingState: { template: "<div class='loading-stub' />" },

--- a/ui/frontend/src/views/consistency/ConsistencyView.vue
+++ b/ui/frontend/src/views/consistency/ConsistencyView.vue
@@ -29,6 +29,7 @@
 
     <template v-else>
       <CatalogConsistencyPanel />
+      <CatalogRemediationPanel />
 
       <section class="health-grid">
         <article class="panel">
@@ -643,6 +644,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import CatalogConsistencyPanel from '@/components/consistency/CatalogConsistencyPanel.vue';
+import CatalogRemediationPanel from '@/components/consistency/CatalogRemediationPanel.vue';
 import ConfirmOperationDialog from '@/components/safety/ConfirmOperationDialog.vue';
 import DisclaimerBanner from '@/components/safety/DisclaimerBanner.vue';
 import ErrorState from '@/components/common/ErrorState.vue';


### PR DESCRIPTION
## Scope
Promotes the currently stable, verified subset from `feature/consistency-remediation` into `main`.

## Included
- catalog remediation flows for broken DB originals, zero-byte findings, and `.fuse_hidden*` storage orphans
- explicit classification and preview/apply separation
- UI support for typed sections, checkbox selection, and bulk actions
- motion/live-photo consistency filtering so valid encoded-video motion components are suppressed from false-positive catalog consistency output
- docs updates for the new consistency/remediation behavior

## Verification
- `uv run ruff check immich_doctor tests`
- `uv run pytest tests/unit/test_catalog_consistency_service.py tests/unit/test_catalog_remediation_service.py tests/unit/test_api_consistency_route.py`
- `npm test -- --run CatalogRemediationPanel.spec.ts ConsistencyView.spec.ts CatalogConsistencyPanel.spec.ts`
- `npm run build`

## Intentionally excluded follow-up
- any future controlled auto-relink or broader rebind heuristics beyond the explicit hash-verified path-fix flow
- future work not yet committed on `feature/consistency-remediation`