### PR TITLE
Refine workflow governance authority and detour rules

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -104,12 +104,12 @@ BRANCH FRESHNESS REQUIREMENT
 Working hierarchy:
 
 - `main` is the public, runnable baseline
-- each work domain or problem owns exactly one active `feature/<feature>`
-- each feature may have at most one active `chore/<feature>/<subtask>` at a time
+- there must be exactly one active `feature/<feature>` workstream at a time
+- the active feature may have at most one active `chore/<feature>/<subtask>` at a time
 - branch topology must follow the work:
-  - `main` -> `feature/<feature>` for the active problem domain
+  - `main` -> `feature/<feature>` for the current active workstream
   - `feature/<feature>` -> optional `chore/<feature>/<subtask>` for a larger isolated work slice
-- small changes may happen directly on `feature/<feature>`
+- small changes may happen directly on the active `feature/<feature>`
 - larger structural changes should typically use `chore/<feature>/<subtask>`
 
 Freshness base mapping:
@@ -120,13 +120,13 @@ Freshness base mapping:
 
 Worktree ownership rules:
 
-- never create a second active `feature/*` for the same domain or subsystem
-- never keep two active `chore/*` branches under the same feature
+- never create or keep a second active `feature/*` while another feature remains unpublished or not fully integrated into `main`
+- never keep two active `chore/*` branches under the active feature
 - if a new larger task arrives while a `chore/<feature>/<subtask>` already exists:
   - if the work is the same in-scope continuation, continue on that chore
-  - if the work is a small additive change, it may happen on the parent feature after integrating the chore first
+  - if the work is a small additive change, it may happen on the active feature after integrating the chore first
   - otherwise integrate the existing chore into its feature first, then create the new chore
-- the parent `feature/*` must remain the latest effective base for its problem domain
+- the active `feature/*` must remain the latest effective base for all unpublished work
 - a `chore/*` must not become a long-lived competing implementation line
 
 Before ANY repository-changing work begins, freshness verification is REQUIRED.
@@ -194,6 +194,7 @@ The agent may continue on the current branch only if ALL are true:
 - branch scope matches the requested task
 - no unrelated leftovers are present
 - no sibling feature or sibling chore branch exists that should be the real current work carrier
+- no other active unpublished feature branch exists that should be integrated first
 - no branch-topology action is required first
 - current branch is not behind canonical base
 
@@ -214,8 +215,8 @@ The agent must STOP before continuing if ANY are true:
 - the requested task changes scope significantly
 - the current branch has already completed its intended slice
 - the requested work should be isolated as a new `chore/<feature>/<subtask>` or `feature/<feature>` branch
-- a second feature branch would be created for the same domain
-- a second chore branch would remain active under the same feature
+- a second active feature branch would remain while another unpublished feature still exists
+- a second chore branch would remain active under the active feature
 - branch cleanup is needed before safe continuation
 - stale non-integrated or already-integrated branches are cluttering workflow visibility
 - relevant unpublished state exists and has not been integrated, synchronized, or explicitly superseded

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -193,6 +193,32 @@ If relevant unpublished state exists, the agent must first do one of:
 Silent ignore of unpublished state is forbidden.
 
 ========================================
+GOVERNANCE AUTHORITY RULE
+========================================
+
+Branch, merge, promotion, cleanup, and workflow-routing decisions must follow the governance rules that are already integrated into `main`.
+
+Non-integrated changes to:
+
+- `.github/AGENTS.md`
+- `.github/agents/*.md`
+
+are not yet authoritative for real repository workflow decisions.
+
+They may be used only when the user explicitly requests:
+
+- a simulation
+- a dry workflow rehearsal
+- or an explicit pre-merge governance test
+
+If the active unpublished workstream changes governance or workflow rules and a later branch/topology decision would rely on those new rules, the agent must first:
+
+1. integrate the governance change into `main`
+2. or explicitly ask the user to treat the next step as simulation only
+
+Starting a new branch from `main` while relying on not-yet-merged governance rules is forbidden.
+
+========================================
 BRANCH CONTINUATION GATE
 ========================================
 
@@ -205,6 +231,7 @@ Mandatory pre-write checks:
 - whether unstaged changes exist
 - whether local unpublished commits exist
 - whether relevant remote unpublished branches or open PRs exist
+- whether unpublished governance changes exist outside `main`
 - whether a suspended active feature exists
 - whether the new task overlaps files, contracts, or subsystem strategy with the suspended feature
 - whether current branch scope matches the requested task
@@ -220,6 +247,7 @@ The agent may continue on the current branch only if ALL are true:
 - no branch-topology action is required first
 - current branch is not behind canonical base
 - any cross-topic detour branch has passed the overlap gate
+- any governance rules being relied on are already integrated into `main` or explicitly marked as simulation-only
 
 ========================================
 UNIFIED PRE-WORK BLOCKER
@@ -241,6 +269,7 @@ The agent must STOP before continuing if ANY are true:
 - a second active feature branch would remain while another unpublished feature still exists
 - a second chore branch would remain active under the active feature
 - a cross-topic detour branch would touch overlapping files, contracts, or subsystem strategy
+- a branch or merge decision would rely on unpublished governance rules not yet integrated into `main`
 - branch cleanup is needed before safe continuation
 - stale non-integrated or already-integrated branches are cluttering workflow visibility
 - relevant unpublished state exists and has not been integrated, synchronized, or explicitly superseded

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -78,8 +78,9 @@ Global rules:
 - Never modify `main` directly
 - All file-changing work must happen on a non-main branch
 - If the current branch is `main` and the task requires file changes:
-  - STOP before making changes
-  - create or switch to the appropriate working branch first
+  - do NOT perform file changes on `main`
+  - automatically create or switch to the appropriate working branch first when task scope is clear
+  - ask only when branch naming or scope is genuinely ambiguous
 - Never push directly to `main`
 - Never leave write tasks with unstaged or uncommitted changes unless the user explicitly asked for a dirty working tree
 - Always report which branch was used for the work
@@ -99,11 +100,33 @@ Delegation rules:
 BRANCH FRESHNESS REQUIREMENT
 ========================================
 
-Canonical base:
+Working hierarchy:
+
+- `main` is the public, runnable baseline
+- each work domain or problem owns exactly one active `feature/<feature>`
+- each feature may have at most one active `chore/<feature>/<subtask>` at a time
+- branch topology must follow the work:
+  - `main` -> `feature/<feature>` for the active problem domain
+  - `feature/<feature>` -> optional `chore/<feature>/<subtask>` for a larger isolated work slice
+- small changes may happen directly on `feature/<feature>`
+- larger structural changes should typically use `chore/<feature>/<subtask>`
+
+Freshness base mapping:
 
 - `feature/*` -> `origin/main`
 - `chore/<feature>/<subtask>` -> `feature/<feature>`
 - `main` -> `origin/main`
+
+Worktree ownership rules:
+
+- never create a second active `feature/*` for the same domain or subsystem
+- never keep two active `chore/*` branches under the same feature
+- if a new larger task arrives while a `chore/<feature>/<subtask>` already exists:
+  - if the work is the same in-scope continuation, continue on that chore
+  - if the work is a small additive change, it may happen on the parent feature after integrating the chore first
+  - otherwise integrate the existing chore into its feature first, then create the new chore
+- the parent `feature/*` must remain the latest effective base for its problem domain
+- a `chore/*` must not become a long-lived competing implementation line
 
 Before ANY repository-changing work begins, freshness verification is REQUIRED.
 
@@ -124,6 +147,31 @@ Checkpoint safety exception:
 - After such checkpoint, no forward-progress work may continue until synchronization completes
 
 ========================================
+PUBLICATION STATE REQUIREMENT
+========================================
+
+Before ANY repository-changing work or topology-changing work begins, publication state verification is REQUIRED.
+
+The agent MUST inspect both local and remote unpublished state, including:
+
+- open PRs that are not merged yet
+- remote `feature/*` or `chore/*` branches not yet integrated into their canonical target
+- local branches with commits not pushed to their upstream
+- local branches whose upstream no longer exists
+
+Treat an open PR as unpublished state until it is merged.
+
+The agent MUST NOT start forward-progress work from an older effective base when relevant unpublished state exists for the same feature, subsystem, or merge target.
+
+If relevant unpublished state exists, the agent must first do one of:
+
+1. integrate it
+2. synchronize onto it
+3. explicitly supersede it with a clear warning and isolation plan
+
+Silent ignore of unpublished state is forbidden.
+
+========================================
 BRANCH CONTINUATION GATE
 ========================================
 
@@ -134,6 +182,8 @@ Mandatory pre-write checks:
 - git status --short
 - whether staged changes exist
 - whether unstaged changes exist
+- whether local unpublished commits exist
+- whether relevant remote unpublished branches or open PRs exist
 - whether current branch scope matches the requested task
 - whether the branch still represents the active intended work slice
 - freshness status vs canonical base
@@ -142,6 +192,7 @@ The agent may continue on the current branch only if ALL are true:
 - working tree is clean, or the existing changes are clearly in-scope carry-over for the same current task
 - branch scope matches the requested task
 - no unrelated leftovers are present
+- no sibling feature or sibling chore branch exists that should be the real current work carrier
 - no branch-topology action is required first
 - current branch is not behind canonical base
 
@@ -153,16 +204,20 @@ Before forward-progress or topology-changing work, ALL must pass:
 
 1. Freshness check passes (branch not behind canonical base)
 2. Canonical base is determinable and reachable
-3. No overlapping/competing active branch work with unclear boundaries
-4. Branch topology and merge target are unambiguous
+3. Publication state is inspected locally and remotely
+4. No overlapping/competing active branch work with unclear boundaries
+5. Branch topology and merge target are unambiguous
 
 The agent must STOP before continuing if ANY are true:
 - the working tree contains unrelated or unclear changes
 - the requested task changes scope significantly
 - the current branch has already completed its intended slice
 - the requested work should be isolated as a new `chore/<feature>/<subtask>` or `feature/<feature>` branch
+- a second feature branch would be created for the same domain
+- a second chore branch would remain active under the same feature
 - branch cleanup is needed before safe continuation
 - stale non-integrated or already-integrated branches are cluttering workflow visibility
+- relevant unpublished state exists and has not been integrated, synchronized, or explicitly superseded
 - freshness check failed
 - canonical base is ambiguous/unreachable
 - overlap/competing work is unresolved
@@ -177,9 +232,10 @@ For every blocked/proceed decision, agent MUST report:
 - current branch
 - canonical base (found/ambiguous/missing)
 - freshness status (ahead/equal/behind)
+- publication state status (clear / local unpublished / remote unpublished / open PR active)
 - overlap/collision status
 - topology clarity status
-- chosen action (proceed / sync first / consolidate first / stop)
+- chosen action (proceed / create-switch branch / sync first / integrate unpublished state first / consolidate first / stop)
 
 Dirty-tree classification is mandatory:
 - in-scope carry-over
@@ -194,6 +250,7 @@ The agent must explicitly report one of:
 - create/switch to new branch
 - cleanup required first
 - synchronize branch with canonical base first
+- integrate unpublished state first
 
 ========================================
 CONSISTENCY AND COLLISION GUARD

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -83,6 +83,7 @@ Global rules:
   - ask only when branch naming or scope is genuinely ambiguous
 - Never push directly to `main`
 - Never leave write tasks with unstaged or uncommitted changes unless the user explicitly asked for a dirty working tree
+- unless the user explicitly requests `stay uncommitted` or equivalent wording, end file-changing work with a checkpoint or other honest commit on the current non-main branch
 - Always report which branch was used for the work
 
 Delegation rules:

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -112,10 +112,21 @@ Working hierarchy:
 - small changes may happen directly on the active `feature/<feature>`
 - larger structural changes should typically use `chore/<feature>/<subtask>`
 
+Exceptional detour branch:
+
+- a short-lived cross-topic detour branch MAY be created when urgent work must land on `main` before the active feature is finished
+- branch form:
+  - `chore/<active-feature>/to-<target-feature>-<subtask>`
+- the `to-<target-feature>` segment is mandatory so the non-parent merge path is obvious
+- this branch does NOT merge back into `feature/<active-feature>`
+- it is a temporary detour from `main` intended to land on `main`, then be deleted
+- after the detour is merged, the previously active feature must be synchronized to the new `main` before continuation
+
 Freshness base mapping:
 
 - `feature/*` -> `origin/main`
 - `chore/<feature>/<subtask>` -> `feature/<feature>`
+- `chore/<active-feature>/to-<target-feature>-<subtask>` -> `origin/main`
 - `main` -> `origin/main`
 
 Worktree ownership rules:
@@ -128,6 +139,13 @@ Worktree ownership rules:
   - otherwise integrate the existing chore into its feature first, then create the new chore
 - the active `feature/*` must remain the latest effective base for all unpublished work
 - a `chore/*` must not become a long-lived competing implementation line
+- a cross-topic detour branch is allowed only when ALL are true:
+  - the current active feature is clean, checkpointed, and intentionally suspended
+  - the detour starts from current `main`
+  - the task is clearly disjoint or safely extractable
+  - the branch name includes the intended target feature via `to-<target-feature>`
+  - the detour is merged to `main` and deleted before resuming the suspended feature
+- if overlap with the suspended feature is unclear or likely, the detour branch is forbidden
 
 Before ANY repository-changing work begins, freshness verification is REQUIRED.
 
@@ -164,6 +182,8 @@ Treat an open PR as unpublished state until it is merged.
 
 The agent MUST NOT start forward-progress work from an older effective base when relevant unpublished state exists for the same feature, subsystem, or merge target.
 
+Cross-topic detour branches are not exempt from this rule.
+
 If relevant unpublished state exists, the agent must first do one of:
 
 1. integrate it
@@ -185,6 +205,8 @@ Mandatory pre-write checks:
 - whether unstaged changes exist
 - whether local unpublished commits exist
 - whether relevant remote unpublished branches or open PRs exist
+- whether a suspended active feature exists
+- whether the new task overlaps files, contracts, or subsystem strategy with the suspended feature
 - whether current branch scope matches the requested task
 - whether the branch still represents the active intended work slice
 - freshness status vs canonical base
@@ -197,6 +219,7 @@ The agent may continue on the current branch only if ALL are true:
 - no other active unpublished feature branch exists that should be integrated first
 - no branch-topology action is required first
 - current branch is not behind canonical base
+- any cross-topic detour branch has passed the overlap gate
 
 ========================================
 UNIFIED PRE-WORK BLOCKER
@@ -217,6 +240,7 @@ The agent must STOP before continuing if ANY are true:
 - the requested work should be isolated as a new `chore/<feature>/<subtask>` or `feature/<feature>` branch
 - a second active feature branch would remain while another unpublished feature still exists
 - a second chore branch would remain active under the active feature
+- a cross-topic detour branch would touch overlapping files, contracts, or subsystem strategy
 - branch cleanup is needed before safe continuation
 - stale non-integrated or already-integrated branches are cluttering workflow visibility
 - relevant unpublished state exists and has not been integrated, synchronized, or explicitly superseded
@@ -270,6 +294,7 @@ Treat as collision when:
 - multiple strategies exist for the same subsystem
 - workflow direction diverges without consolidation
 - new work would partially undo recent work without explicit acknowledgment
+- a detour branch from `main` would edit the same files, interfaces, or subsystem decisions as a suspended feature
 
 Required behavior on collision:
 

--- a/.github/agents/control-plane.agent.md
+++ b/.github/agents/control-plane.agent.md
@@ -10,6 +10,7 @@ Rules:
 - Inspect `.github/AGENTS.md` first.
 - Inspect available agent files under `.github/agents/`.
 - Choose exactly one correct repository agent for the task.
+- If the selected task requires file changes and the current branch is `main`, route through canonical `workflow.begin` semantics before file-changing work starts.
 - If agent selection is ambiguous, STOP.
 - On ambiguity, report: candidate agents, ambiguity reason, and why selection is blocked.
 - Do not fall back to generic behavior when ambiguity exists.

--- a/.github/agents/docs.agent.md
+++ b/.github/agents/docs.agent.md
@@ -5,6 +5,7 @@ Keep documentation aligned with implemented system reality.
 Global rules (mandatory, canonical in `.github/AGENTS.md`):
 
 - For repository-changing docs work, apply `BRANCH FRESHNESS REQUIREMENT`
+- For repository-changing docs work, apply `PUBLICATION STATE REQUIREMENT`
 - Apply `BRANCH CONTINUATION GATE` before file-changing docs work
 - Apply `UNIFIED PRE-WORK BLOCKER` when docs workflow affects branch topology or overlap routing
 - Apply `CONSISTENCY AND COLLISION GUARD` before introducing/rewriting subsystem narratives

--- a/.github/agents/refactor.agent.md
+++ b/.github/agents/refactor.agent.md
@@ -28,6 +28,7 @@ Escalation:
 
 - if current branch is `main` and the refactor scope is clear, initiate canonical branch creation through `workflow.begin` semantics instead of stopping on `main`
 - if another active chore already exists under the same feature and the requested work is a distinct larger slice, integrate that chore first instead of creating a parallel chore
+- if a cross-topic detour branch is considered, require a strict overlap check first; when overlap is unclear or likely, STOP instead of opening the detour
 - if synchronization, branch creation, promotion, merge prep, or cleanup is needed -> use `workflow.agent`
 - if behavioral change is required -> STOP and request explicit scope change
 - when a chore branch is required, use canonical naming `chore/<feature>/<subtask>`

--- a/.github/agents/refactor.agent.md
+++ b/.github/agents/refactor.agent.md
@@ -5,6 +5,7 @@ Perform safe structural improvements without changing behavior.
 Global rules (mandatory, canonical in `.github/AGENTS.md`):
 
 - Apply `BRANCH FRESHNESS REQUIREMENT` before forward-progress refactor work
+- Apply `PUBLICATION STATE REQUIREMENT` before forward-progress refactor work
 - Apply `BRANCH CONTINUATION GATE` before any file-changing work
 - Apply `UNIFIED PRE-WORK BLOCKER` before topology/branch-impacting refactor operations
 - Apply `CONSISTENCY AND COLLISION GUARD` before structural consolidation
@@ -25,6 +26,8 @@ Strict stops:
 
 Escalation:
 
+- if current branch is `main` and the refactor scope is clear, initiate canonical branch creation through `workflow.begin` semantics instead of stopping on `main`
+- if another active chore already exists under the same feature and the requested work is a distinct larger slice, integrate that chore first instead of creating a parallel chore
 - if synchronization, branch creation, promotion, merge prep, or cleanup is needed -> use `workflow.agent`
 - if behavioral change is required -> STOP and request explicit scope change
 - when a chore branch is required, use canonical naming `chore/<feature>/<subtask>`

--- a/.github/agents/workflow.agent.md
+++ b/.github/agents/workflow.agent.md
@@ -18,10 +18,10 @@ This agent MUST apply global rules from `.github/AGENTS.md`.
 ## Branch model
 
 - `main` is protected and must never receive direct work commits
-- each work domain owns exactly one active `feature/*`
-- `feature/*` is the canonical current work carrier for that domain
-- `chore/<feature>/<subtask>` is an optional short-lived, scoped isolation branch under that feature
-- at most one active `chore/*` may exist under the same feature at a time
+- there is exactly one active `feature/*` workstream at a time until it is integrated into `main`
+- `feature/*` is the canonical current work carrier for all unpublished work
+- `chore/<feature>/<subtask>` is an optional short-lived, scoped isolation branch under that active feature
+- at most one active `chore/*` may exist under the active feature at a time
 - non-canonical `fix/*` branches are retained and reported unless verified safe for cleanup
 
 ## Shortcut invocation syntax
@@ -74,7 +74,15 @@ Required action:
 2. synchronize onto it
 3. or explicitly supersede it with a clear warning and isolation plan
 
-If an active sibling `chore/*` already exists under the same feature, do not start a second one.
+If another unpublished active `feature/*` exists, do not start a second feature.
+
+Required action:
+
+1. integrate the current active feature into `main`
+2. clean fully integrated branches
+3. only then create the next feature
+
+If an active `chore/*` already exists under the active feature, do not start a second one.
 
 Required action:
 

--- a/.github/agents/workflow.agent.md
+++ b/.github/agents/workflow.agent.md
@@ -1,32 +1,34 @@
 # Workflow Agent
 
 Purpose:
-Provide repository workflow operations (branch lifecycle, promotion, cleanup, artifact shipping).
+Provide repository workflow operations for branch lifecycle, promotion, merge preparation, cleanup, and shipping.
 
 This agent MUST apply global rules from `.github/AGENTS.md`.
 
-## Global dependency map (canonical source)
+## Canonical dependencies
 
-- Branch freshness + canonical base: `BRANCH FRESHNESS REQUIREMENT`
-- Continuation decision: `BRANCH CONTINUATION GATE`
-- Hard preconditions before forward-progress/topology changes: `UNIFIED PRE-WORK BLOCKER`
-- Stale-branch checkpoint handling: `BRANCH FRESHNESS REQUIREMENT` (checkpoint safety exception)
-- Collision handling: `CONSISTENCY AND COLLISION GUARD`
-- Reporting fields: `MANDATORY REPORTING CONTRACT`
-- Main protection / PR discipline: `GIT AND BRANCH SAFETY`
+- branch freshness and canonical base -> `BRANCH FRESHNESS REQUIREMENT`
+- unpublished/open-PR awareness -> `PUBLICATION STATE REQUIREMENT`
+- continuation decision -> `BRANCH CONTINUATION GATE`
+- hard preconditions before forward progress or topology changes -> `UNIFIED PRE-WORK BLOCKER`
+- collision handling -> `CONSISTENCY AND COLLISION GUARD`
+- reporting fields -> `MANDATORY REPORTING CONTRACT`
+- main protection and branch safety -> `GIT AND BRANCH SAFETY`
 
-## Branch model (workflow-specific)
+## Branch model
 
-- `main` is protected
-- `feature/*` carries major work
-- `chore/<feature>/<subtask>` carries short-lived feature subtasks
-- non-canonical `fix/*` is retained/reported unless verified for safe deletion
+- `main` is protected and must never receive direct work commits
+- each work domain owns exactly one active `feature/*`
+- `feature/*` is the canonical current work carrier for that domain
+- `chore/<feature>/<subtask>` is an optional short-lived, scoped isolation branch under that feature
+- at most one active `chore/*` may exist under the same feature at a time
+- non-canonical `fix/*` branches are retained and reported unless verified safe for cleanup
 
-## Shortcut invocation syntax (canonical)
+## Shortcut invocation syntax
 
-- Canonical form: `workflow.<shortcut>`
-- Optional alias form: `.<shortcut>`
-- Do not mix undocumented invocation styles.
+- canonical form: `workflow.<shortcut>`
+- optional alias form: `.<shortcut>`
+- do not mix undocumented invocation styles
 
 ## Shortcut catalog
 
@@ -34,9 +36,55 @@ This agent MUST apply global rules from `.github/AGENTS.md`.
 
 Alias equivalents: `.begin` `.checkpoint` `.docs` `.audit` `.ship` `.ready` `.promoteMain` `.toMain` `.cleanBranches` `.end`
 
----
+## Execution model
 
-## .begin
+Workflow shortcuts are target-state requests, not narrow branch-shape assertions.
+
+The workflow agent MUST satisfy missing prerequisite stages automatically when:
+
+- the next step is deterministic
+- branch topology is clear
+- required validation can still be performed honestly
+- no freshness/publication/collision blocker is active
+
+The workflow agent MUST NOT stop merely because the user invoked a later-stage shortcut from an earlier branch level if the required chain is clear and safe.
+
+Examples:
+
+- invoking `workflow.begin` on `main` for a file-changing task means: create the canonical working branch stack automatically
+- invoking `workflow.promoteMain` on `chore/<feature>/<subtask>` means: checkpoint if needed -> optional docs sync if narrow and factual -> checkpoint docs if changed -> `workflow.ready` -> synchronize feature state -> promote stable subset to `main`
+- invoking `workflow.toMain` on `chore/<feature>/<subtask>` means: checkpoint if needed -> optional docs sync if narrow and factual -> checkpoint docs if changed -> `workflow.ready` -> synchronize feature state -> choose `workflow.toMain` if the feature is honestly complete, otherwise choose `workflow.promoteMain` -> `workflow.cleanBranches`
+
+The workflow agent must prefer the least-destructive chain that satisfies the user goal of getting the current validated state onto `main`.
+
+## Publication gate
+
+Before any workflow shortcut that changes topology, merges branches, or starts new work, inspect:
+
+- local unpublished commits
+- remote unpublished feature/chore branches
+- open PRs not yet merged
+- upstream branches that disappeared but still have local history
+
+If relevant unpublished state exists for the same scope, do not continue from an older effective base.
+
+Required action:
+
+1. integrate it
+2. synchronize onto it
+3. or explicitly supersede it with a clear warning and isolation plan
+
+If an active sibling `chore/*` already exists under the same feature, do not start a second one.
+
+Required action:
+
+1. continue the existing chore if the task is the same work slice
+2. integrate the existing chore into the parent feature first if the new task is a distinct larger slice
+3. only then create the new chore
+
+## Shortcut reference
+
+### `workflow.begin`
 
 Purpose:
 Start work on the correct branch level.
@@ -45,22 +93,28 @@ Input:
 `workflow.begin <feature>/<subtask>`
 
 Preconditions:
+
 - current branch is `main` or `feature/<feature>`
 - input has exactly two kebab-case segments
 - apply `UNIFIED PRE-WORK BLOCKER`
 
 STOP if:
-- current branch is `chore/<feature>/<subtask>`
+
+- current branch is already `chore/<feature>/<subtask>` and the request would duplicate active scope
 - feature segment mismatches current `feature/*`
 - input normalization fails
-- blocker fails
+- blockers fail
 
 Deterministic outcome:
+
 - from `main` -> create/switch `feature/<feature>`, then create/switch `chore/<feature>/<subtask>`
 - from `feature/<feature>` -> create/switch `chore/<feature>/<subtask>`
+- if a sibling chore already exists under that feature:
+  - continue it when the task is the same slice
+  - otherwise integrate it first, then create the new chore
 - active branch after success is always `chore/<feature>/<subtask>`
 
-## .checkpoint
+### `workflow.checkpoint`
 
 Purpose:
 Create an intermediate checkpoint.
@@ -69,24 +123,28 @@ Input:
 `workflow.checkpoint [topic]`
 
 Preconditions:
+
 - current branch is not `main`
 - working tree state is readable
 
 Behavior:
+
 - if branch is fresh: normal checkpoint
-- if branch is stale: allow checkpoint ONLY as safety-preserving action per global checkpoint exception
+- if branch is stale: allow checkpoint only as safety-preserving action per global checkpoint exception
 
 STOP if:
+
 - unresolved conflicts
 - repository state unclear
-- changes too mixed for one honest checkpoint commit
+- changes are too mixed for one honest checkpoint commit
 
 Deterministic outcome:
+
 - stage + commit + push
 - no merge
-- if stale-branch checkpoint: explicitly report "sync required before continued forward-progress"
+- if stale-branch checkpoint: explicitly report `sync required before continued forward-progress`
 
-## .docs
+### `workflow.docs`
 
 Purpose:
 Small documentation synchronization only.
@@ -95,20 +153,23 @@ Input:
 `workflow.docs`
 
 Preconditions:
+
 - documentation-only, narrow scope
 - apply `BRANCH CONTINUATION GATE`
 - for repository-changing docs work, apply `BRANCH FRESHNESS REQUIREMENT`
 
 STOP if:
-- implementation truth unclear
+
+- implementation truth is unclear
 - scope is rewrite/architecture/new subsystem docs/release notes/UX system docs
 
 Deterministic outcome:
+
 - minimal factual doc correction only
 - no product logic changes
 - hand off broad docs work to `docs.agent`
 
-## .audit
+### `workflow.audit`
 
 Purpose:
 Read-only consistency and risk audit.
@@ -117,39 +178,45 @@ Input:
 `workflow.audit [scope]`
 
 Preconditions:
+
 - repository state readable
 - scope is inspectable read-only
 
 STOP if:
+
 - scope unverifiable
 
 Deterministic outcome:
-- read-only findings with priorities
-- include freshness/collision risk observations where relevant
 
-## .ship
+- read-only findings with priorities
+- include freshness/publication/collision observations where relevant
+
+### `workflow.ship`
 
 Purpose:
-Build and verify artifacts/images.
+Build and verify artifacts or images.
 
 Input:
 `workflow.ship`
 
 Preconditions:
-- repository state safe for build/packaging
+
+- repository state safe for build and packaging
 
 STOP if:
+
 - build fails
 - verification fails
-- repository state unsafe
+- repository state is unsafe
 
 Deterministic outcome:
-- run build/package
-- verify outputs
-- report exact artifact names/tags
-- no implicit merge/publish
 
-## .ready
+- run build or package
+- verify outputs
+- report exact artifact names or tags
+- no implicit merge or publish
+
+### `workflow.ready`
 
 Purpose:
 Promote `chore/<feature>/<subtask>` into its parent `feature/*`.
@@ -158,73 +225,107 @@ Input:
 `workflow.ready`
 
 Preconditions:
+
 - current branch is `chore/<feature>/<subtask>`
-- parent `feature/*` determinable
+- parent `feature/*` is determinable
 - required checks complete
 - apply `UNIFIED PRE-WORK BLOCKER`
 
+Automatic prerequisite chain:
+
+- if the worktree is dirty -> `workflow.checkpoint`
+- if small factual docs drift is detected -> `workflow.docs`, then `workflow.checkpoint`
+
 STOP if:
-- parent relation unclear
-- blocker fails
-- conflicts/check failures after required sync/merge
+
+- parent relation is unclear
+- blockers fail
+- conflicts or required checks fail after sync or merge
 
 Deterministic outcome:
-- merge/ff chore into parent feature
-- push feature
-- delete source branch if safe
 
-## .promoteMain
+- merge or fast-forward chore into parent feature
+- push feature
+- delete source chore branch if safe
+
+### `workflow.promoteMain`
 
 Purpose:
-Merge stable subset of current `feature/*` into `main` via PR while keeping feature active.
+Merge a stable subset of current work into `main` via PR while keeping the broader feature active when needed.
 
 Input:
 `workflow.promoteMain`
 
+Accepted current branches:
+
+- `feature/*`
+- `chore/<feature>/<subtask>` through automatic prerequisite chaining
+
 Preconditions:
-- current branch is `feature/*`
-- promoted scope is runnable/validated and improves `main`
+
+- promoted scope is runnable, validated, and improves `main`
 - apply `UNIFIED PRE-WORK BLOCKER`
 
+Automatic prerequisite chain:
+
+- from `chore/<feature>/<subtask>` -> `workflow.checkpoint` if needed -> optional `workflow.docs` -> checkpoint docs if changed -> `workflow.ready`
+- from resulting `feature/*` -> inspect publication state and synchronize onto the latest effective base before PR creation
+
 STOP if:
-- stable subset not safely isolatable
-- blocker fails
+
+- stable subset is not safely isolatable
+- blockers fail
 - required checks fail
-- mergeability unclear
+- mergeability is unclear
 
 Deterministic outcome:
-- prepare promotable full scope or safe subset
-- push branch/extraction branch if needed
-- open/update PR to `main`
-- merge only through PR when checks are green
-- keep feature branch active
 
-## .toMain
+- prepare promotable full scope or safe subset
+- push branch or extraction branch if needed
+- open or update PR to `main`
+- merge only through PR when checks are green
+- keep the feature branch active unless cleanup proves it is fully integrated
+
+### `workflow.toMain`
 
 Purpose:
-Merge complete `feature/*` into `main` via PR.
+Get the current validated work onto `main`.
 
 Input:
 `workflow.toMain`
 
+Accepted current branches:
+
+- `feature/*`
+- `chore/<feature>/<subtask>` through automatic prerequisite chaining
+
 Preconditions:
-- current branch is `feature/*`
-- feature complete, runnable, validated
-- related chores already merged
+
 - apply `UNIFIED PRE-WORK BLOCKER`
+- current state is runnable and validated
+
+Automatic prerequisite chain:
+
+- from `chore/<feature>/<subtask>` -> `workflow.checkpoint` if needed -> optional `workflow.docs` -> checkpoint docs if changed -> `workflow.ready`
+- synchronize resulting `feature/*` with the latest effective base, including relevant unpublished/open-PR state
+- if the feature is honestly complete -> continue with full `toMain`
+- otherwise -> downgrade safely to `workflow.promoteMain`
+- after successful merge to `main` -> `workflow.cleanBranches`
 
 STOP if:
-- feature incomplete/unclear
-- blocker fails
-- required checks fail
-- selective subset would be required
+
+- required blockers fail
+- mergeability or publication state is unclear
+- validation fails
 
 Deterministic outcome:
-- push feature branch
-- open/update PR to `main`
-- merge via PR when checks are green
 
-## .cleanBranches
+- push required branch state
+- open or update PR to `main`
+- merge via PR when checks are green
+- clean fully integrated branches afterward
+
+### `workflow.cleanBranches`
 
 Purpose:
 Delete branches already fully integrated into canonical targets.
@@ -233,24 +334,29 @@ Input:
 `workflow.cleanBranches`
 
 Preconditions:
-- repository state readable
-- remote state fetchable
-- apply `UNIFIED PRE-WORK BLOCKER` elements relevant to topology/deletion
+
+- repository state is readable
+- remote state is fetchable
+- apply relevant `UNIFIED PRE-WORK BLOCKER` elements for topology and deletion
 
 Mandatory pre-step:
+
 - `fetch --all --prune`
 
 STOP if:
+
 - integration status cannot be verified clearly
-- relation/target ambiguous
-- unresolved conflicts/state ambiguity
+- relation or target is ambiguous
+- unresolved conflicts or state ambiguity exists
 
 Deterministic outcome:
-- evaluate `chore/<feature>/<subtask>` against parent feature, `feature/*` against `origin/main`
-- delete local/remote branches only when verified integrated
+
+- evaluate `chore/<feature>/<subtask>` against parent feature
+- evaluate `feature/*` against `origin/main`
+- delete local and remote branches only when verified integrated
 - report retained branches with reasons
 
-## .end
+### `workflow.end`
 
 Purpose:
 End session safely without merge claim.
@@ -259,14 +365,17 @@ Input:
 `workflow.end`
 
 Preconditions:
-- repository state readable
+
+- repository state is readable
 
 STOP if:
+
 - unresolved conflicts
-- repository state unclear
+- repository state is unclear
 
 Deterministic outcome:
-- stage+commit if needed
+
+- stage + commit if needed
 - push current branch
-- report branch + freshness status + next recommended action
+- report branch, freshness status, publication state, and next recommended action
 - no merge

--- a/.github/agents/workflow.agent.md
+++ b/.github/agents/workflow.agent.md
@@ -22,6 +22,9 @@ This agent MUST apply global rules from `.github/AGENTS.md`.
 - `feature/*` is the canonical current work carrier for all unpublished work
 - `chore/<feature>/<subtask>` is an optional short-lived, scoped isolation branch under that active feature
 - at most one active `chore/*` may exist under the active feature at a time
+- exception: a temporary cross-topic detour branch may use
+  - `chore/<active-feature>/to-<target-feature>-<subtask>`
+  - it starts from `main`, lands on `main`, and must be deleted before the suspended feature resumes
 - non-canonical `fix/*` branches are retained and reported unless verified safe for cleanup
 
 ## Shortcut invocation syntax
@@ -90,6 +93,16 @@ Required action:
 2. integrate the existing chore into the parent feature first if the new task is a distinct larger slice
 3. only then create the new chore
 
+Detour exception:
+
+- a temporary cross-topic detour branch may be created only when ALL are true:
+  - the active feature is clean, checkpointed, and intentionally suspended
+  - the detour work is urgent
+  - the detour starts from current `main`
+  - overlap with the suspended feature is demonstrably absent or safely extractable
+  - the branch name contains `to-<target-feature>`
+- if overlap is unclear, likely, or strategic rather than surgical, STOP instead of creating the detour
+
 ## Shortcut reference
 
 ### `workflow.begin`
@@ -120,7 +133,10 @@ Deterministic outcome:
 - if a sibling chore already exists under that feature:
   - continue it when the task is the same slice
   - otherwise integrate it first, then create the new chore
-- active branch after success is always `chore/<feature>/<subtask>`
+- for an approved detour request:
+  - checkpoint and suspend the active feature if needed
+  - create `chore/<active-feature>/to-<target-feature>-<subtask>` from current `main`
+- active branch after success is the created or selected working branch, either standard `chore/<feature>/<subtask>` or approved detour `chore/<active-feature>/to-<target-feature>-<subtask>`
 
 ### `workflow.checkpoint`
 
@@ -247,6 +263,7 @@ Automatic prerequisite chain:
 STOP if:
 
 - parent relation is unclear
+- the branch is a `to-<target-feature>` detour branch
 - blockers fail
 - conflicts or required checks fail after sync or merge
 
@@ -268,6 +285,7 @@ Accepted current branches:
 
 - `feature/*`
 - `chore/<feature>/<subtask>` through automatic prerequisite chaining
+- `chore/<active-feature>/to-<target-feature>-<subtask>` as a detour branch that promotes directly to `main`
 
 Preconditions:
 
@@ -278,6 +296,7 @@ Automatic prerequisite chain:
 
 - from `chore/<feature>/<subtask>` -> `workflow.checkpoint` if needed -> optional `workflow.docs` -> checkpoint docs if changed -> `workflow.ready`
 - from resulting `feature/*` -> inspect publication state and synchronize onto the latest effective base before PR creation
+- from `chore/<active-feature>/to-<target-feature>-<subtask>` -> checkpoint if needed -> verify overlap gate passed -> promote directly to `main` without `workflow.ready`
 
 STOP if:
 
@@ -293,6 +312,9 @@ Deterministic outcome:
 - open or update PR to `main`
 - merge only through PR when checks are green
 - keep the feature branch active unless cleanup proves it is fully integrated
+- if the source is a detour branch:
+  - delete the detour after merge
+  - synchronize the suspended active feature to the new `main` before resuming work
 
 ### `workflow.toMain`
 

--- a/.github/agents/workflow.agent.md
+++ b/.github/agents/workflow.agent.md
@@ -9,6 +9,7 @@ This agent MUST apply global rules from `.github/AGENTS.md`.
 
 - branch freshness and canonical base -> `BRANCH FRESHNESS REQUIREMENT`
 - unpublished/open-PR awareness -> `PUBLICATION STATE REQUIREMENT`
+- authoritative rule source -> `GOVERNANCE AUTHORITY RULE`
 - continuation decision -> `BRANCH CONTINUATION GATE`
 - hard preconditions before forward progress or topology changes -> `UNIFIED PRE-WORK BLOCKER`
 - collision handling -> `CONSISTENCY AND COLLISION GUARD`
@@ -49,6 +50,7 @@ The workflow agent MUST satisfy missing prerequisite stages automatically when:
 - branch topology is clear
 - required validation can still be performed honestly
 - no freshness/publication/collision blocker is active
+- no governance-authority blocker is active
 
 The workflow agent MUST NOT stop merely because the user invoked a later-stage shortcut from an earlier branch level if the required chain is clear and safe.
 
@@ -60,6 +62,8 @@ Examples:
 
 The workflow agent must prefer the least-destructive chain that satisfies the user goal of getting the current validated state onto `main`.
 
+The workflow agent must not use unpublished governance changes as binding workflow law unless the user explicitly requested a simulation or rehearsal.
+
 ## Publication gate
 
 Before any workflow shortcut that changes topology, merges branches, or starts new work, inspect:
@@ -68,6 +72,7 @@ Before any workflow shortcut that changes topology, merges branches, or starts n
 - remote unpublished feature/chore branches
 - open PRs not yet merged
 - upstream branches that disappeared but still have local history
+- unpublished governance changes that would alter the decision logic itself
 
 If relevant unpublished state exists for the same scope, do not continue from an older effective base.
 
@@ -76,6 +81,8 @@ Required action:
 1. integrate it
 2. synchronize onto it
 3. or explicitly supersede it with a clear warning and isolation plan
+
+If unpublished governance changes would be required to justify the next workflow step, integrate those governance changes into `main` first unless the user explicitly asked for simulation only.
 
 If another unpublished active `feature/*` exists, do not start a second feature.
 


### PR DESCRIPTION
## Summary
- tighten workflow governance around active feature/chore ownership and detour branches
- require governance and workflow rules to be authoritative only after integration into main
- block branch and merge decisions that rely on unpublished governance changes

## Verification
- governance/docs only; no runtime code changed
- rely on repository CI checks for merge gating