### PR TITLE
Move configured roots to settings

### DIFF
--- a/ui/frontend/src/stores/catalog.ts
+++ b/ui/frontend/src/stores/catalog.ts
@@ -4,7 +4,6 @@ import { ApiClientError } from "@/api/client";
 import {
   fetchCatalogScanJob,
   fetchCatalogStatus,
-  fetchCatalogZeroByte,
   pauseCatalogScanJob,
   requestCatalogScanWorkers,
   resumeCatalogScanJob,
@@ -79,7 +78,6 @@ function isActiveScanJob(job: CatalogWorkflowJobRecord | null): boolean {
 
 export const useCatalogStore = defineStore("catalog", () => {
   const statusReport = ref<CatalogValidationReport | null>(null);
-  const zeroByteReport = ref<CatalogValidationReport | null>(null);
   const scanJob = ref<CatalogWorkflowJobRecord | null>(null);
   const roots = ref<CatalogRootRow[]>([]);
   const selectedRoot = ref<string | null>(null);
@@ -93,9 +91,7 @@ export const useCatalogStore = defineStore("catalog", () => {
     const statusResponse = await fetchCatalogStatus(rootSlug);
     const nextRoots = extractRoots(statusResponse.data);
     const normalizedRoot = normalizeSelectedRoot(rootSlug, nextRoots);
-    const zeroByteResponse = await fetchCatalogZeroByte(normalizedRoot);
     statusReport.value = statusResponse.data;
-    zeroByteReport.value = zeroByteResponse.data;
     roots.value = nextRoots;
     selectedRoot.value = normalizedRoot;
   }
@@ -256,6 +252,5 @@ export const useCatalogStore = defineStore("catalog", () => {
     shouldAutoStartScan,
     startScan,
     statusReport,
-    zeroByteReport,
   };
 });

--- a/ui/frontend/src/views/settings/SettingsView.spec.ts
+++ b/ui/frontend/src/views/settings/SettingsView.spec.ts
@@ -3,6 +3,22 @@ import { nextTick } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsView from "./SettingsView.vue";
 
+function createCatalogStore() {
+  return {
+    roots: [
+      {
+        slug: "uploads",
+        setting_name: "immich_uploads_path",
+        root_type: "source",
+        absolute_path: "/mnt/immich/storage/upload",
+      },
+    ],
+    rootCount: 1,
+    error: null as string | null,
+    load: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function createStore() {
   return {
     overview: {
@@ -42,9 +58,14 @@ function createStore() {
 }
 
 let store = createStore();
+let catalogStore = createCatalogStore();
 
 vi.mock("@/stores/settings", () => ({
   useSettingsStore: () => store,
+}));
+
+vi.mock("@/stores/catalog", () => ({
+  useCatalogStore: () => catalogStore,
 }));
 
 function mountView() {
@@ -68,6 +89,7 @@ async function settle() {
 describe("SettingsView", () => {
   beforeEach(() => {
     store = createStore();
+    catalogStore = createCatalogStore();
     vi.clearAllMocks();
   });
 
@@ -75,6 +97,10 @@ describe("SettingsView", () => {
     const wrapper = mountView();
     await settle();
 
+    expect(store.load).toHaveBeenCalled();
+    expect(catalogStore.load).toHaveBeenCalled();
+    expect(wrapper.text()).toContain("Configured roots");
+    expect(wrapper.text()).toContain("/mnt/immich/storage/upload");
     expect(wrapper.text()).not.toContain("Testbed dump reload");
   });
 

--- a/ui/frontend/src/views/settings/SettingsView.vue
+++ b/ui/frontend/src/views/settings/SettingsView.vue
@@ -36,6 +36,39 @@
         </article>
       </section>
 
+      <section class="panel settings-overview-card">
+        <div class="settings-section__header">
+          <div>
+            <h3>Configured roots</h3>
+            <p>Root registration comes from the runtime container paths, not guessed host paths.</p>
+          </div>
+        </div>
+        <p class="settings-overview-card__summary">
+          {{ catalogStore.rootCount }} configured storage roots are currently visible to the catalog runtime.
+        </p>
+        <p v-if="catalogStore.error" class="runtime-blocking-message">
+          {{ catalogStore.error }}
+        </p>
+        <section v-else-if="catalogStore.roots.length" class="runtime-findings">
+          <article
+            v-for="root in catalogStore.roots"
+            :key="root.slug"
+            class="runtime-finding"
+          >
+            <div class="runtime-finding__header">
+              <strong>{{ root.slug }}</strong>
+            </div>
+            <span>{{ root.absolute_path }}</span>
+            <small>{{ root.root_type }} via {{ root.setting_name }}</small>
+          </article>
+        </section>
+        <EmptyState
+          v-else
+          title="No catalog roots configured"
+          message="Set at least one Immich storage path in the runtime environment before using the persistent catalog."
+        />
+      </section>
+
       <section
         v-if="settingsStore.testbedDump?.enabled"
         class="panel settings-testbed-card"
@@ -152,9 +185,11 @@ import CapabilityTag from "@/components/common/CapabilityTag.vue";
 import EmptyState from "@/components/common/EmptyState.vue";
 import LoadingState from "@/components/common/LoadingState.vue";
 import PageHeader from "@/components/common/PageHeader.vue";
+import { useCatalogStore } from "@/stores/catalog";
 import { useSettingsStore } from "@/stores/settings";
 
 const settingsStore = useSettingsStore();
+const catalogStore = useCatalogStore();
 const importPath = ref("");
 const importFormat = ref("auto");
 const importConfirmed = ref(false);
@@ -189,6 +224,6 @@ async function triggerImport(): Promise<void> {
 }
 
 onMounted(async () => {
-  await settingsStore.load();
+  await Promise.all([settingsStore.load(), catalogStore.load()]);
 });
 </script>

--- a/ui/frontend/src/views/storage/StorageView.spec.ts
+++ b/ui/frontend/src/views/storage/StorageView.spec.ts
@@ -9,7 +9,6 @@ const catalogStore: {
   hasCommittedSnapshot: boolean;
   shouldAutoStartScan: boolean;
   statusReport: Record<string, unknown>;
-  zeroByteReport: Record<string, unknown>;
   scanJob: Record<string, unknown> | null;
   scanRuntime: Record<string, unknown> | null;
   scanJobActive: boolean;
@@ -115,38 +114,6 @@ const catalogStore: {
     metrics: [],
     recommendations: [],
   },
-  zeroByteReport: {
-    domain: "analyze.catalog",
-    action: "zero-byte",
-    status: "FAIL",
-    summary: "Loaded 1 zero-byte file findings from the latest committed catalog snapshots.",
-    generated_at: "2026-04-08T09:02:00+00:00",
-    metadata: {
-      catalog_path: "/data/manifests/catalog/file-catalog.sqlite3",
-      root_slug: "uploads",
-    },
-    checks: [],
-    sections: [
-      {
-        name: "ZERO_BYTE_FILES",
-        status: "fail",
-        rows: [
-          {
-            root_slug: "uploads",
-            relative_path: "nested/empty.jpg",
-            file_name: "empty.jpg",
-            extension: ".jpg",
-            size_bytes: 0,
-            modified_at_fs: "2026-04-08T09:01:00+00:00",
-            snapshot_id: 7,
-            generation: 2,
-          },
-        ],
-      },
-    ],
-    metrics: [],
-    recommendations: [],
-  },
   scanJob: {
     jobId: "catalog-scan-1",
     jobType: "catalog_inventory_scan",
@@ -223,10 +190,11 @@ describe("StorageView", () => {
 
     expect(wrapper.text()).toContain("Storage index scan");
     expect(wrapper.text()).toContain("generation 2");
-    expect(wrapper.text()).toContain("nested/empty.jpg");
     expect(wrapper.text()).toContain("Directories: 4 / 4");
     expect(wrapper.text()).toContain("Configured workers: 4");
     expect(wrapper.text()).toContain("Active workers: 0");
+    expect(wrapper.text()).not.toContain("Configured roots");
+    expect(wrapper.text()).not.toContain("Zero-byte files");
 
     const runButton = wrapper
       .findAll("button")

--- a/ui/frontend/src/views/storage/StorageView.vue
+++ b/ui/frontend/src/views/storage/StorageView.vue
@@ -3,7 +3,7 @@
     <PageHeader
       eyebrow="Storage / Catalog"
       title="Persistent Catalog"
-      summary="Cached storage scan, persisted status, zero-byte detection, and reusable inventory for consistency validation."
+      summary="Cached storage scan, persisted status, and reusable inventory for consistency validation."
     />
     <RiskNotice
       title="Read-only storage inventory"
@@ -13,7 +13,7 @@
     <LoadingState
       v-if="catalogStore.isLoading && !catalogStore.statusReport"
       title="Loading catalog state"
-      message="Collecting configured roots, latest snapshots, zero-byte findings, and current scan state."
+      message="Collecting configured roots, latest snapshots, and current scan state."
     />
     <ErrorState
       v-else-if="catalogStore.error"
@@ -117,8 +117,6 @@
           <dl class="runtime-detail__grid">
             <dt>Scope</dt>
             <dd>{{ selectedRootLabel }}</dd>
-            <dt>Configured roots</dt>
-            <dd>{{ catalogStore.rootCount }}</dd>
             <dt>Latest snapshot</dt>
             <dd>{{ latestSnapshotLabel }}</dd>
             <dt>Files indexed</dt>
@@ -129,86 +127,7 @@
             <dd>{{ latestSession?.directories_completed ?? 0 }}</dd>
           </dl>
         </article>
-
-        <article class="panel catalog-panel">
-          <div class="settings-section__header">
-            <div>
-              <h3>Zero-byte summary</h3>
-              <p>Obvious defects from the latest committed catalog snapshots.</p>
-            </div>
-            <StatusTag :status="zeroByteStatus" />
-          </div>
-
-          <p class="health-card__summary">{{ zeroByteRows.length }} zero-byte sample rows</p>
-          <p class="health-card__details">
-            {{ catalogStore.zeroByteReport?.summary ?? "No zero-byte report loaded." }}
-          </p>
-        </article>
       </section>
-
-      <article class="panel catalog-panel">
-        <div class="settings-section__header">
-          <div>
-            <h3>Configured roots</h3>
-            <p>Root registration comes from the runtime container paths, not guessed host paths.</p>
-          </div>
-        </div>
-        <section v-if="catalogStore.roots.length" class="runtime-findings">
-          <article
-            v-for="root in catalogStore.roots"
-            :key="root.slug"
-            class="runtime-finding"
-            :class="{ 'catalog-root--selected': root.slug === catalogStore.selectedRoot }"
-          >
-            <div class="runtime-finding__header">
-              <strong>{{ root.slug }}</strong>
-              <StatusTag :status="root.slug === catalogStore.selectedRoot ? 'ok' : 'unknown'" />
-            </div>
-            <span>{{ root.absolute_path }}</span>
-            <small>{{ root.root_type }} via {{ root.setting_name }}</small>
-          </article>
-        </section>
-        <EmptyState
-          v-else
-          title="No catalog roots configured"
-          message="Set at least one Immich storage path in the runtime environment before using the persistent catalog."
-        />
-      </article>
-
-      <article class="panel catalog-panel">
-        <div class="settings-section__header">
-          <div>
-            <h3>Zero-byte files</h3>
-            <p>Read-only findings from the latest committed snapshot for the selected scope.</p>
-          </div>
-        </div>
-
-        <EmptyState
-          v-if="!zeroByteRows.length"
-          title="No zero-byte files found"
-          message="Run a catalog scan to populate the persisted inventory, then review findings here."
-        />
-        <div v-else class="catalog-table-wrapper">
-          <table class="catalog-table">
-            <thead>
-              <tr>
-                <th>Root</th>
-                <th>Relative path</th>
-                <th>Size</th>
-                <th>Snapshot</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="row in zeroByteRows" :key="`${row.root_slug}:${row.relative_path}`">
-                <td>{{ row.root_slug }}</td>
-                <td>{{ row.relative_path }}</td>
-                <td>{{ row.size_bytes }} bytes</td>
-                <td>#{{ row.generation }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </article>
     </template>
   </section>
 </template>
@@ -227,7 +146,6 @@ import type {
   CatalogSessionRow,
   CatalogSnapshotRow,
   CatalogValidationReport,
-  CatalogZeroByteRow,
 } from "@/api/types/catalog";
 
 const catalogStore = useCatalogStore();
@@ -259,9 +177,6 @@ function toUiStatus(value: string | null | undefined): "ok" | "warning" | "error
   return "unknown";
 }
 
-const zeroByteRows = computed<CatalogZeroByteRow[]>(() =>
-  getSectionRows<CatalogZeroByteRow>(catalogStore.zeroByteReport, "ZERO_BYTE_FILES"),
-);
 const latestSnapshots = computed<CatalogSnapshotRow[]>(() =>
   getSectionRows<CatalogSnapshotRow>(catalogStore.statusReport, "LATEST_SNAPSHOTS"),
 );
@@ -387,8 +302,6 @@ const scanPanelStatus = computed(() => {
   return toUiStatus(catalogStore.scanJob?.state ?? latestSession.value?.status);
 });
 const latestSessionStatus = computed(() => toUiStatus(latestSession.value?.status));
-const zeroByteStatus = computed(() => (zeroByteRows.value.length ? "error" : "ok"));
-
 async function runScan(): Promise<void> {
   await catalogStore.startScan(true);
 }


### PR DESCRIPTION
## Summary
- move the configured roots card from Storage to Settings
- remove the duplicate zero-byte panel from Storage
- stop loading the storage zero-byte report for the Storage page

## Verification
- npm test -- --run StorageView.spec.ts SettingsView.spec.ts
- npm run build