### PR TITLE
Stabilize consistency loading and remediation cards

### DIFF
--- a/ui/frontend/src/api/catalog.ts
+++ b/ui/frontend/src/api/catalog.ts
@@ -8,6 +8,9 @@ import type {
   CatalogWorkflowJobRecord,
 } from "./types/catalog";
 
+const CATALOG_READ_TIMEOUT_MS = 30000;
+const CATALOG_JOB_TIMEOUT_MS = 15000;
+
 function buildQuery(params: Record<string, string | number | null | undefined>): string {
   const search = new URLSearchParams();
   Object.entries(params).forEach(([key, value]) => {
@@ -32,7 +35,11 @@ export async function startCatalogScan(
 export async function fetchCatalogStatus(
   root?: string | null,
 ): Promise<ApiResponse<CatalogValidationReport>> {
-  return request<CatalogValidationReport>(`/analyze/catalog/status${buildQuery({ root })}`);
+  return request<CatalogValidationReport>(
+    `/analyze/catalog/status${buildQuery({ root })}`,
+    undefined,
+    CATALOG_READ_TIMEOUT_MS,
+  );
 }
 
 export async function fetchCatalogZeroByte(
@@ -45,7 +52,11 @@ export async function fetchCatalogZeroByte(
 }
 
 export async function fetchCatalogScanJob(): Promise<ApiResponse<CatalogWorkflowJobRecord>> {
-  return request<CatalogWorkflowJobRecord>("/analyze/catalog/scan-job");
+  return request<CatalogWorkflowJobRecord>(
+    "/analyze/catalog/scan-job",
+    undefined,
+    CATALOG_JOB_TIMEOUT_MS,
+  );
 }
 
 export async function startCatalogScanJob(

--- a/ui/frontend/src/api/database.ts
+++ b/ui/frontend/src/api/database.ts
@@ -2,6 +2,12 @@ import { request } from "./client";
 import type { ApiResponse } from "./types/common";
 import type { DatabaseOverviewResponse } from "./types/database";
 
+const DATABASE_OVERVIEW_TIMEOUT_MS = 30000;
+
 export async function fetchDatabaseOverview(): Promise<ApiResponse<DatabaseOverviewResponse>> {
-  return request<DatabaseOverviewResponse>("/health/database");
+  return request<DatabaseOverviewResponse>(
+    "/health/database",
+    undefined,
+    DATABASE_OVERVIEW_TIMEOUT_MS,
+  );
 }

--- a/ui/frontend/src/components/consistency/CatalogRemediationPanel.spec.ts
+++ b/ui/frontend/src/components/consistency/CatalogRemediationPanel.spec.ts
@@ -43,6 +43,18 @@ function createStore(): any {
             },
           ],
         },
+        {
+          name: "ZERO_BYTE_FILES",
+          rows: [
+            {
+              root_slug: "uploads",
+              relative_path: "user-a/raw-zero.jpg",
+              file_name: "raw-zero.jpg",
+              size_bytes: 0,
+              generation: 2,
+            },
+          ],
+        },
       ],
     },
     remediationScanResult: {
@@ -190,6 +202,11 @@ describe("CatalogRemediationPanel", () => {
     expect(wrapper.text()).toContain("`.fuse_hidden*` artifacts");
     expect(wrapper.text()).not.toContain("Preview");
     expect(wrapper.text()).not.toContain("Apply");
+
+    const groupCards = wrapper.findAll(".catalog-remediation-group");
+    expect(groupCards.length).toBeGreaterThanOrEqual(5);
+    expect(groupCards.some((card) => card.text().includes("DB originals missing in storage"))).toBe(true);
+    expect(groupCards.some((card) => card.text().includes("Storage originals missing in DB"))).toBe(true);
   });
 
   it("stages context-sensitive bulk actions only for selected eligible rows", async () => {
@@ -239,5 +256,23 @@ describe("CatalogRemediationPanel", () => {
     expect(wrapper.text()).toContain("Repair path");
     expect(wrapper.text()).toContain("Quarantine");
     expect(wrapper.text()).toContain("Ignore");
+  });
+
+  it("falls back to raw zero-byte snapshot rows when remediation enrichment is unavailable", async () => {
+    store.zeroByteFindings = [];
+
+    const wrapper = mount(CatalogRemediationPanel, {
+      global: {
+        stubs: {
+          EmptyState: { template: "<div>{{ title }} {{ message }}</div>", props: ["title", "message"] },
+          StatusTag: { template: "<span>{{ status }}</span>", props: ["status"] },
+        },
+      },
+    });
+    await nextTick();
+
+    expect(wrapper.text()).toContain("raw-zero.jpg");
+    expect(wrapper.text()).toContain("Zero-byte snapshot");
+    expect(wrapper.text()).toContain("Detailed remediation classification is not loaded.");
   });
 });

--- a/ui/frontend/src/components/consistency/CatalogRemediationPanel.vue
+++ b/ui/frontend/src/components/consistency/CatalogRemediationPanel.vue
@@ -1,5 +1,6 @@
 <template>
-  <section class="panel catalog-remediation-panel">
+  <section class="catalog-remediation-panel">
+    <section class="panel catalog-remediation-workspace">
     <div class="settings-section__header">
       <div>
         <h3>Catalog findings workspace</h3>
@@ -86,6 +87,7 @@
         </span>
       </div>
     </section>
+    </section>
 
     <EmptyState
       v-if="!findingGroups.length"
@@ -96,7 +98,7 @@
     <article
       v-for="group in findingGroups"
       :key="group.key"
-      class="catalog-remediation-group"
+      class="panel catalog-remediation-group"
     >
       <div class="settings-section__header">
         <div>
@@ -455,6 +457,28 @@ function zeroByteRow(finding: ZeroByteFinding): FindingRowModel {
   };
 }
 
+function fallbackZeroByteRow(row: Record<string, unknown>): FindingRowModel {
+  const relativePath = String(row.relative_path ?? "Unavailable");
+  const fileName = String(row.file_name ?? relativePath);
+  return {
+    id: `fallback-zero-byte:${relativePath}`,
+    groupKey: "zero-byte",
+    title: fileName,
+    subtitle: String(row.root_slug ?? "unknown"),
+    badgeLabel: "Zero-byte snapshot",
+    badgeClass: badgeClass("zero_byte_upload_orphan"),
+    message: "A zero-byte file exists in the snapshot, but detailed remediation classification is unavailable right now.",
+    pathDetails: [
+      pathLine("Relative path", relativePath),
+      pathLine("Size", `${String(row.size_bytes ?? "0")} B`),
+    ],
+    statusReason: "Inspect only until remediation enrichment loads.",
+    blockedReason: "Detailed remediation classification is not loaded.",
+    actions: [makeRowAction("inspect", "Inspect", "Review the raw zero-byte snapshot finding.", null)],
+    selectionEligible: false,
+  };
+}
+
 function fuseHiddenRow(finding: FuseHiddenOrphanFinding): FindingRowModel {
   const actions: RowActionModel[] = [];
   if (finding.classification === "deletable_orphan") {
@@ -520,9 +544,12 @@ const storageMissingRows = computed<FindingRowModel[]>(() =>
 const orphanDerivativeRows = computed<FindingRowModel[]>(() =>
   consistencyStore.orphanDerivatives.map(orphanDerivativeRow),
 );
-const zeroByteRows = computed<FindingRowModel[]>(() =>
-  consistencyStore.zeroByteFindings.map(zeroByteRow),
-);
+const zeroByteRows = computed<FindingRowModel[]>(() => {
+  if (consistencyStore.zeroByteFindings.length) {
+    return consistencyStore.zeroByteFindings.map(zeroByteRow);
+  }
+  return sectionRows(report.value, "ZERO_BYTE_FILES").map(fallbackZeroByteRow);
+});
 const fuseHiddenRows = computed<FindingRowModel[]>(() =>
   consistencyStore.fuseHiddenOrphans.map(fuseHiddenRow),
 );
@@ -687,6 +714,7 @@ async function refreshPanel(): Promise<void> {
 
 <style scoped>
 .catalog-remediation-panel,
+.catalog-remediation-workspace,
 .catalog-remediation-group,
 .catalog-remediation-stage {
   display: grid;

--- a/ui/frontend/src/stores/catalog.ts
+++ b/ui/frontend/src/stores/catalog.ts
@@ -109,13 +109,21 @@ export const useCatalogStore = defineStore("catalog", () => {
   async function load(rootSlug: string | null = selectedRoot.value): Promise<void> {
     isLoading.value = true;
     error.value = null;
-    try {
-      await Promise.all([loadReports(rootSlug), loadScanJob()]);
-    } catch (caughtError) {
-      error.value = toErrorMessage(caughtError);
-    } finally {
-      isLoading.value = false;
+    scanError.value = null;
+    const [reportsResult, scanJobResult] = await Promise.allSettled([
+      loadReports(rootSlug),
+      loadScanJob(),
+    ]);
+
+    if (reportsResult.status === "rejected") {
+      error.value = toErrorMessage(reportsResult.reason);
     }
+
+    if (scanJobResult.status === "rejected") {
+      scanError.value = toErrorMessage(scanJobResult.reason);
+    }
+
+    isLoading.value = false;
   }
 
   async function refresh(): Promise<void> {

--- a/ui/frontend/src/views/database/DatabaseView.spec.ts
+++ b/ui/frontend/src/views/database/DatabaseView.spec.ts
@@ -48,7 +48,7 @@ function createStore() {
       testedAgainstImmichVersion: "2.5.6",
     },
     isLoading: false,
-    error: null,
+    error: null as string | null,
     load: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -87,5 +87,28 @@ describe("DatabaseView", () => {
     expect(wrapper.text()).toContain("Detected Immich 2.5.6 with schema profile supported.");
     expect(wrapper.text()).toContain("Consistency findings are waiting for a current storage index.");
     expect(wrapper.text()).toContain("Immich 2.5.6");
+  });
+
+  it("keeps cached database details visible when a later refresh error exists", async () => {
+    store.error = "Request timed out.";
+
+    const wrapper = mount(DatabaseView, {
+      global: {
+        stubs: {
+          PageHeader: { template: "<div class='page-header-stub' />" },
+          DisclaimerBanner: { template: "<div class='disclaimer-stub' />" },
+          RiskNotice: { template: "<div class='risk-notice-stub'>{{ message }}</div>", props: ["message"] },
+          LoadingState: { template: "<div class='loading-stub' />" },
+          ErrorState: { template: "<div class='error-stub'>error</div>" },
+          StatusTag: { template: "<span class='status-tag-stub'>{{ status }}</span>", props: ["status"] },
+          RouterLink: { template: "<a><slot /></a>" },
+        },
+      },
+    });
+
+    await Promise.resolve();
+
+    expect(wrapper.text()).toContain("Database access works against postgres:5432.");
+    expect(wrapper.text()).not.toContain("error");
   });
 });

--- a/ui/frontend/src/views/storage/StorageView.spec.ts
+++ b/ui/frontend/src/views/storage/StorageView.spec.ts
@@ -221,4 +221,28 @@ describe("StorageView", () => {
     const stopButton = wrapper.findAll("button").find((button) => button.text() === "Stop");
     expect(stopButton).toBeTruthy();
   });
+
+  it("keeps cached storage status visible when a later request error exists", async () => {
+    catalogStore.error = "Request timed out.";
+
+    const wrapper = mount(StorageView, {
+      global: {
+        stubs: {
+          PageHeader: { template: "<div><slot /></div>" },
+          RiskNotice: { template: "<div><slot /></div>", props: ["title", "message"] },
+          LoadingState: { template: "<div />" },
+          ErrorState: { template: "<div class='error-stub'>error</div>" },
+          EmptyState: { template: "<div>{{ title }} {{ message }}</div>", props: ["title", "message"] },
+          StatusTag: { template: "<span>{{ status }}</span>", props: ["status"] },
+        },
+      },
+    });
+
+    await nextTick();
+    await nextTick();
+
+    expect(wrapper.text()).toContain("Storage index scan");
+    expect(wrapper.text()).toContain("Request timed out.");
+    expect(wrapper.text()).not.toContain("error");
+  });
 });

--- a/ui/frontend/src/views/storage/StorageView.vue
+++ b/ui/frontend/src/views/storage/StorageView.vue
@@ -16,11 +16,17 @@
       message="Collecting configured roots, latest snapshots, and current scan state."
     />
     <ErrorState
-      v-else-if="catalogStore.error"
+      v-else-if="catalogStore.error && !catalogStore.statusReport"
       title="Catalog state unavailable"
       :message="catalogStore.error"
     />
     <template v-else>
+      <p
+        v-if="catalogStore.error && catalogStore.statusReport"
+        class="runtime-blocking-message"
+      >
+        {{ catalogStore.error }}
+      </p>
       <section class="settings-grid">
         <article class="panel catalog-panel">
           <div class="settings-section__header">


### PR DESCRIPTION
## Summary
- split consistency remediation findings into clearer cards
- restore zero-byte visibility in consistency via remediation fallback
- stabilize database/storage overview loading so cached data is not replaced by timeout errors

## Verification
- npm test -- --run CatalogRemediationPanel.spec.ts ConsistencyView.spec.ts CatalogConsistencyPanel.spec.ts
- npm test -- --run DatabaseView.spec.ts StorageView.spec.ts
- npm run build