### PR TITLE
Governance: enforce project-tracked issue gate in workflow

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -177,6 +177,8 @@ The agent MUST inspect both local and remote unpublished state, including:
 - remote `feature/*` or `chore/*` branches not yet integrated into their canonical target
 - local branches with commits not pushed to their upstream
 - local branches whose upstream no longer exists
+- matching GitHub Project tracked item for the requested task scope
+- canonical task-tracking Issue existence for that tracked item scope
 
 Treat an open PR as unpublished state until it is merged.
 
@@ -189,6 +191,12 @@ If relevant unpublished state exists, the agent must first do one of:
 1. integrate it
 2. synchronize onto it
 3. explicitly supersede it with a clear warning and isolation plan
+
+Task-tracking requirement is mandatory:
+
+- before starting task work, there must be a corresponding Issue tracked in GitHub Project
+- tracked item form may be Issue card or PR card, but task tracking MUST resolve to an Issue
+- if no matching Issue exists, create it and add/link it in the GitHub Project before forward-progress work
 
 Silent ignore of unpublished state is forbidden.
 
@@ -260,6 +268,7 @@ Before forward-progress or topology-changing work, ALL must pass:
 3. Publication state is inspected locally and remotely
 4. No overlapping/competing active branch work with unclear boundaries
 5. Branch topology and merge target are unambiguous
+6. Requested task has a corresponding Issue tracked in GitHub Project (created if missing)
 
 The agent must STOP before continuing if ANY are true:
 - the working tree contains unrelated or unclear changes
@@ -277,6 +286,7 @@ The agent must STOP before continuing if ANY are true:
 - canonical base is ambiguous/unreachable
 - overlap/competing work is unresolved
 - branch topology is ambiguous/inconsistent
+- no corresponding GitHub Project tracked Issue exists for the requested task
 
 ========================================
 MANDATORY REPORTING CONTRACT
@@ -288,9 +298,12 @@ For every blocked/proceed decision, agent MUST report:
 - canonical base (found/ambiguous/missing)
 - freshness status (ahead/equal/behind)
 - publication state status (clear / local unpublished / remote unpublished / open PR active)
+- task-tracking status (tracked Issue found / created now / missing-blocked)
 - overlap/collision status
 - topology clarity status
 - chosen action (proceed / create-switch branch / sync first / integrate unpublished state first / consolidate first / stop)
+
+When running `workflow.toMain`, reporting MUST also include tracked item transition status for repository taxonomy (for example `Review`/`Done`, including equivalent wording such as `prüfen`/`fertig`).
 
 Dirty-tree classification is mandatory:
 - in-scope carry-over

--- a/.github/agents/workflow.agent.md
+++ b/.github/agents/workflow.agent.md
@@ -73,8 +73,16 @@ Before any workflow shortcut that changes topology, merges branches, or starts n
 - open PRs not yet merged
 - upstream branches that disappeared but still have local history
 - unpublished governance changes that would alter the decision logic itself
+- matching GitHub Project tracked item for the requested task scope
+- canonical task-tracking Issue existence for that scope
 
 If relevant unpublished state exists for the same scope, do not continue from an older effective base.
+
+Task tracking is mandatory before forward-progress workflow actions:
+
+- there must be a corresponding Issue tracked in GitHub Project before task start
+- tracked item may be Issue or PR card, but the work item must resolve to an Issue
+- if no matching Issue exists, create the Issue and add/link it in GitHub Project before continuing
 
 Required action:
 
@@ -124,6 +132,7 @@ Preconditions:
 
 - current branch is `main` or `feature/<feature>`
 - input has exactly two kebab-case segments
+- corresponding task Issue exists and is tracked in GitHub Project (create + link first if missing)
 - apply `UNIFIED PRE-WORK BLOCKER`
 
 STOP if:
@@ -340,6 +349,7 @@ Preconditions:
 
 - apply `UNIFIED PRE-WORK BLOCKER`
 - current state is runnable and validated
+- corresponding task Issue is tracked in GitHub Project and ready for transition update on merge
 
 Automatic prerequisite chain:
 
@@ -360,6 +370,7 @@ Deterministic outcome:
 - push required branch state
 - open or update PR to `main`
 - merge via PR when checks are green
+- update/move the tracked project item to review/done semantics according to repository status taxonomy (for example `Review` then `Done`, including equivalent wording such as `prüfen`/`fertig`)
 - clean fully integrated branches afterward
 
 ### `workflow.cleanBranches`


### PR DESCRIPTION
## Summary\n- enforce mandatory GitHub Project + Issue tracking requirement before forward-progress workflow actions\n- extend unified pre-work blocker and mandatory reporting contract with task-tracking status\n- align workflow agent publication gate and toMain reporting expectations\n\nCloses #34