### PR TITLE
Accept Immich 2.7.5 compatibility

### DIFF
--- a/immich_doctor/adapters/postgres.py
+++ b/immich_doctor/adapters/postgres.py
@@ -471,8 +471,11 @@ class PostgresAdapter:
             sql.SQL('"updatedAt" AS "updatedAt"'),
             sql.SQL('"originalFileName" AS "originalFileName"'),
             sql.SQL('"originalPath" AS "originalPath"'),
-            sql.SQL('"encodedVideoPath" AS "encodedVideoPath"'),
         ]
+        if "encodedVideoPath" in asset_columns:
+            select_columns.append(sql.SQL('"encodedVideoPath" AS "encodedVideoPath"'))
+        else:
+            select_columns.append(sql.SQL('NULL::text AS "encodedVideoPath"'))
         for column in optional_columns:
             select_columns.append(
                 sql.SQL("{column} AS {alias}").format(

--- a/immich_doctor/services/database_overview.py
+++ b/immich_doctor/services/database_overview.py
@@ -12,7 +12,7 @@ from immich_doctor.db.health.service import DbHealthCheckService
 from immich_doctor.db.schema_detection import DatabaseSchemaSupportStatus, DatabaseStateDetector
 from immich_doctor.services.dashboard_health import DashboardHealthStatus
 
-SUPPORTED_IMMICH_TEST_VERSION = "2.5.6"
+SUPPORTED_IMMICH_TEST_VERSION = "2.7.5"
 
 
 def _iso_now() -> str:

--- a/tests/unit/test_api_health_route.py
+++ b/tests/unit/test_api_health_route.py
@@ -90,9 +90,9 @@ def test_database_overview_route_returns_expected_shape(monkeypatch) -> None:
             },
             "immich": {
                 "status": "ok",
-                "summary": "Detected Immich 2.5.6.",
+                "summary": "Detected Immich 2.7.5.",
                 "details": "Version history is available.",
-                "productVersionCurrent": "2.5.6",
+                "productVersionCurrent": "2.7.5",
                 "productVersionConfidence": "high",
                 "productVersionSource": "version_history",
                 "supportStatus": "supported",
@@ -102,9 +102,9 @@ def test_database_overview_route_returns_expected_shape(monkeypatch) -> None:
             },
             "compatibility": {
                 "status": "ok",
-                "summary": "Detected Immich 2.5.6 matches the tested target.",
+                "summary": "Detected Immich 2.7.5 matches the tested target.",
                 "details": "Schema support is modeled.",
-                "testedAgainstImmichVersion": "2.5.6",
+                "testedAgainstImmichVersion": "2.7.5",
             },
             "relatedFindings": {
                 "status": "warning",
@@ -112,7 +112,7 @@ def test_database_overview_route_returns_expected_shape(monkeypatch) -> None:
                 "details": "Open the Consistency page for details.",
                 "route": "/consistency",
             },
-            "testedAgainstImmichVersion": "2.5.6",
+            "testedAgainstImmichVersion": "2.7.5",
         },
     )
 
@@ -122,5 +122,5 @@ def test_database_overview_route_returns_expected_shape(monkeypatch) -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["data"]["connectivity"]["serverVersion"] == "14.10"
-    assert payload["data"]["immich"]["productVersionCurrent"] == "2.5.6"
+    assert payload["data"]["immich"]["productVersionCurrent"] == "2.7.5"
     assert payload["data"]["relatedFindings"]["route"] == "/consistency"

--- a/tests/unit/test_consistency_service.py
+++ b/tests/unit/test_consistency_service.py
@@ -205,7 +205,7 @@ def _version_history_entries() -> list[dict[str, object]]:
         {
             "entry_id": "vh-1",
             "created_at": "2026-03-07T23:06:01+00:00",
-            "version": "2.5.6",
+            "version": "2.7.5",
         }
     ]
 
@@ -253,7 +253,7 @@ def test_consistency_validation_supports_album_asset_asset_id_variant() -> None:
 
     assert result.consistency_summary.profile_supported is True
     assert result.consistency_summary.asset_reference_column == "assetId"
-    assert result.consistency_summary.product_version_current == "2.5.6"
+    assert result.consistency_summary.product_version_current == "2.7.5"
     assert result.consistency_summary.schema_generation_key is not None
 
 

--- a/tests/unit/test_database_overview_service.py
+++ b/tests/unit/test_database_overview_service.py
@@ -72,7 +72,7 @@ def test_database_overview_service_reports_supported_tested_version() -> None:
         ),
         schema_detector=_FakeSchemaDetector(
             {
-                "product_version_current": "2.5.6",
+                "product_version_current": "2.7.5",
                 "product_version_confidence": "high",
                 "product_version_source": "version_history",
                 "support_status": "supported",
@@ -100,9 +100,9 @@ def test_database_overview_service_reports_supported_tested_version() -> None:
     )
 
     assert overview["connectivity"]["status"] == "ok"
-    assert overview["immich"]["productVersionCurrent"] == "2.5.6"
+    assert overview["immich"]["productVersionCurrent"] == "2.7.5"
     assert overview["compatibility"]["status"] == "ok"
-    assert overview["testedAgainstImmichVersion"] == "2.5.6"
+    assert overview["testedAgainstImmichVersion"] == "2.7.5"
 
 
 def test_database_overview_service_marks_related_findings_as_waiting_during_indexing() -> None:

--- a/tests/unit/test_database_state_detector.py
+++ b/tests/unit/test_database_state_detector.py
@@ -222,7 +222,7 @@ def _version_history_entries() -> list[dict[str, object]]:
         {
             "entry_id": "vh-1",
             "created_at": "2026-03-07T23:06:01+00:00",
-            "version": "2.5.6",
+            "version": "2.7.5",
         },
         {
             "entry_id": "vh-0",
@@ -244,7 +244,7 @@ def test_database_state_detector_reads_version_history_when_present() -> None:
 
     state = detector.detect("dsn", 5)
 
-    assert state.product_version_current == "2.5.6"
+    assert state.product_version_current == "2.7.5"
     assert state.product_version_confidence.value == "high"
     assert len(state.product_version_history) == 2
     assert state.support_status == DatabaseSchemaSupportStatus.SUPPORTED

--- a/tests/unit/test_postgres_adapter_catalog.py
+++ b/tests/unit/test_postgres_adapter_catalog.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+from immich_doctor.adapters import postgres as postgres_module
+from immich_doctor.adapters.postgres import PostgresAdapter
+
+
+def test_catalog_asset_listing_projects_null_encoded_video_path_when_column_is_absent(
+    monkeypatch,
+) -> None:
+    adapter = PostgresAdapter()
+
+    def fake_list_columns(*args: Any, **kwargs: Any) -> list[dict[str, object]]:
+        del args, kwargs
+        return [
+            {"column_name": "id"},
+            {"column_name": "type"},
+            {"column_name": "ownerId"},
+            {"column_name": "createdAt"},
+            {"column_name": "updatedAt"},
+            {"column_name": "originalFileName"},
+            {"column_name": "originalPath"},
+            {"column_name": "checksumAlgorithm"},
+        ]
+
+    def fake_fetch_all_composed(*args: Any, **kwargs: Any) -> list[dict[str, object]]:
+        del kwargs
+        query = args[2]
+        query_repr = repr(query)
+        assert "NULL::text" in query_repr
+        assert "encodedVideoPath" in query_repr
+        assert "checksumAlgorithm" in query_repr
+        return [{"id": "asset-1", "encodedVideoPath": None}]
+
+    monkeypatch.setattr(adapter, "list_columns", fake_list_columns)
+    monkeypatch.setattr(postgres_module, "fetch_all_composed", fake_fetch_all_composed)
+
+    rows = adapter.list_all_assets_for_catalog_consistency(
+        "postgresql://postgres:postgres@localhost:5432/immich",
+        3,
+    )
+
+    assert rows == [{"id": "asset-1", "encodedVideoPath": None}]

--- a/tests/unit/test_text_writer_consistency.py
+++ b/tests/unit/test_text_writer_consistency.py
@@ -21,7 +21,7 @@ def _summary(profile_supported: bool = True) -> ConsistencySummary:
         profile_name="immich_db_schema_detection_v1",
         profile_supported=profile_supported,
         support_status="supported" if profile_supported else "unsupported",
-        product_version_current="2.5.6" if profile_supported else None,
+        product_version_current="2.7.5" if profile_supported else None,
         product_version_confidence="high" if profile_supported else "unknown",
         schema_generation_key="immich_schema:album_asset.assetId+memory_asset+album_thumbnail_asset+stack_primary_asset+version_history",
         schema_fingerprint="abc123",
@@ -66,7 +66,7 @@ def test_consistency_validation_text_output_groups_by_category() -> None:
     output = render_text_report(report)
 
     assert "Database State:" in output
-    assert "product_version=2.5.6" in output
+    assert "product_version=2.7.5" in output
     assert "asset_reference_column=assetId" in output
     assert "Categories:" in output
     assert "db.orphan.album_asset.missing_asset" in output

--- a/ui/frontend/src/views/database/DatabaseView.spec.ts
+++ b/ui/frontend/src/views/database/DatabaseView.spec.ts
@@ -23,9 +23,9 @@ function createStore() {
       },
       immich: {
         status: "ok",
-        summary: "Detected Immich 2.5.6 with schema profile supported.",
-        details: "Immich version signal: 2.5.6 (source: version_history, confidence: high).",
-        productVersionCurrent: "2.5.6",
+        summary: "Detected Immich 2.7.5 with schema profile supported.",
+        details: "Immich version signal: 2.7.5 (source: version_history, confidence: high).",
+        productVersionCurrent: "2.7.5",
         productVersionConfidence: "high",
         productVersionSource: "version_history",
         supportStatus: "supported",
@@ -35,9 +35,9 @@ function createStore() {
       },
       compatibility: {
         status: "ok",
-        summary: "Detected Immich 2.5.6, which matches the currently tested validation target.",
+        summary: "Detected Immich 2.7.5, which matches the currently tested validation target.",
         details: "This compatibility signal comes from schema detection plus version_history metadata.",
-        testedAgainstImmichVersion: "2.5.6",
+        testedAgainstImmichVersion: "2.7.5",
       },
       relatedFindings: {
         status: "warning",
@@ -45,7 +45,7 @@ function createStore() {
         details: "Open the Consistency page for detailed compare rows and repair workflows.",
         route: "/consistency",
       },
-      testedAgainstImmichVersion: "2.5.6",
+      testedAgainstImmichVersion: "2.7.5",
     },
     isLoading: false,
     error: null as string | null,
@@ -84,9 +84,9 @@ describe("DatabaseView", () => {
 
     expect(store.load).toHaveBeenCalled();
     expect(wrapper.text()).toContain("Database access works against postgres:5432.");
-    expect(wrapper.text()).toContain("Detected Immich 2.5.6 with schema profile supported.");
+    expect(wrapper.text()).toContain("Detected Immich 2.7.5 with schema profile supported.");
     expect(wrapper.text()).toContain("Consistency findings are waiting for a current storage index.");
-    expect(wrapper.text()).toContain("Immich 2.5.6");
+    expect(wrapper.text()).toContain("Immich 2.7.5");
   });
 
   it("keeps cached database details visible when a later refresh error exists", async () => {

--- a/ui/frontend/src/views/database/DatabaseView.vue
+++ b/ui/frontend/src/views/database/DatabaseView.vue
@@ -165,7 +165,7 @@ import { useDatabaseStore } from "@/stores/database";
 const databaseStore = useDatabaseStore();
 const overview = computed(() => databaseStore.overview);
 const testedAgainstVersion = computed(
-  () => overview.value?.testedAgainstImmichVersion ?? "2.5.6",
+  () => overview.value?.testedAgainstImmichVersion ?? "2.7.5",
 );
 
 function formatDate(value: string): string {


### PR DESCRIPTION
## Summary

- accept Immich 2.7.5 as the tested compatibility target
- keep catalog consistency compatible with Immich 2.7.5 schemas where `public.asset.encodedVideoPath` is absent
- update backend, UI, and test expectations from 2.5.6 to 2.7.5

## Validation

- real temporary Immich v2.7.5 Docker runtime/schema validation
- `runtime health check`: PASS
- `db health check`: PASS
- `consistency validate`: PASS
- `analyze catalog consistency`: completed after the schema-aware fallback
- `uv run pytest`: 276 passed
- `npm test`: 36 passed

Tracking: #146