### PR TITLE
chore: restore shared serena project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,18 @@ dev/testbed/imports/
 dev/testbed/exports/
 dev/testbed/tmp/
 __Temp/
+
+# Serena project config: track stable project.yml and shared memories; ignore local/runtime state.
+.serena/.gitignore
+.serena/project.local.yml
+.serena/cache/
+.serena/logs/
+.serena/index/
+.serena/.cache/
+.serena/tmp/
+.serena/memories/local/
+.serena/memories/local/**
+.serena/memories/tmp/
+.serena/memories/tmp/**
+.serena/memories/local_*.md
+.serena/memories/tmp_*.md

--- a/.serena/memories/architecture.md
+++ b/.serena/memories/architecture.md
@@ -1,0 +1,8 @@
+# Architecture Notes
+
+- Service-layer workflow logic belongs in `immich_doctor/services` or domain packages, not in UI components or route handlers.
+- API routes should adapt service results into response models and keep business workflow decisions out of the transport layer.
+- Reports and persistent workflow artifacts are part of traceability; avoid replacing them with UI-only state.
+- Repair and quarantine flows must stay narrow, explicit, and reversible where the existing model requires it.
+- Catalog-backed consistency state is a canonical direction; avoid adding competing ad-hoc scan state unless a migration plan exists.
+- Frontend stores/components should consume typed API contracts from `ui/frontend/src/api/types` and avoid duplicating backend rules.

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,7 @@
+# Core Project Memory
+
+- Project: `immich-doctor`, Python 3.12+ CLI/API/UI toolkit for safe Immich maintenance, validation, backup, consistency, and repair workflows.
+- Start with repository governance before changing files: `.github/AGENTS.md`, then the relevant `.github/agents/*.agent.md`.
+- Key context memories: project overview in `mem:project_overview`, architecture boundaries in `mem:architecture`, development commands in `mem:development_commands`, workflow rules in `mem:workflow_governance`, Serena handling in `mem:serena_project_state`.
+- Preserve operator safety: validation-first behavior, dry-run/default-safe repair behavior, explicit reports, traceability, and no silent broadening of destructive workflows.
+- Serena project files are repository-relevant configuration. Do not delete `.serena/` as cleanup. Only remove known generated/runtime paths when they are ignored and clearly disposable.

--- a/.serena/memories/development_commands.md
+++ b/.serena/memories/development_commands.md
@@ -1,0 +1,10 @@
+# Development Commands
+
+- Python lint: `uv run ruff check .`
+- Python format check: `uv run ruff format --check .`
+- Python tests: `uv run pytest`
+- Frontend install from lockfile: `npm ci` in `ui/frontend`
+- Frontend tests: `npm test` in `ui/frontend`
+- Frontend build/typecheck: `npm run build` in `ui/frontend`
+- Frontend audit gate used during dependency work: `npm audit --audit-level=moderate` in `ui/frontend`
+- Before reporting CI parity for lint, run both Ruff check and Ruff format check; CI runs both.

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone, 
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets. 
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes. 
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,8 @@
+# Project Overview
+
+- `immich-doctor` is a maintenance, validation, and repair toolkit for Immich installations.
+- Current product shape: Python backend/CLI plus Vue frontend under `ui/frontend`.
+- Python package root: `immich_doctor/`; tests under `tests/unit` and `tests/integration`.
+- Main domains: runtime validation, storage checks, database health, consistency analysis/repair, backup targets/execution, catalog-backed workflows, reports, and API/UI presentation.
+- Documentation lives under `docs/`; workflow-specific docs are under `docs/workflows/`.
+- Frontend source lives under `ui/frontend/src`; API client/types live under `ui/frontend/src/api`.

--- a/.serena/memories/serena_project_state.md
+++ b/.serena/memories/serena_project_state.md
@@ -1,0 +1,8 @@
+# Serena Project State
+
+- Stable Serena project configuration is intended to be tracked: `.serena/project.yml` and shared memories under `.serena/memories/*.md`.
+- `.serena/project.yml` intentionally keeps `included_optional_tools` and `fixed_tools` empty for the Codex context; Codex file and shell operations stay with Codex' native tools, while Serena provides symbolic/code-intelligence tools. The project is Python with UTF-8 encoding.
+- Local-only Serena state is ignored from the root `.gitignore`: `.serena/project.local.yml`, cache/index/log/tmp folders, and local/tmp memories.
+- Do not add a separate `.serena/.gitignore` unless the root `.gitignore` approach becomes insufficient.
+- Never delete `.serena/` wholesale during cleanup. If cleanup is needed, delete only known ignored runtime paths after checking `git status --short --ignored` and `git check-ignore -v`.
+- Shared memories should contain durable, non-secret project conventions. Personal notes, temporary task notes, and machine-specific details belong in ignored local/tmp memory paths.

--- a/.serena/memories/workflow_governance.md
+++ b/.serena/memories/workflow_governance.md
@@ -1,0 +1,9 @@
+# Workflow Governance
+
+- `main` is protected; do not make direct work commits on `main`.
+- Use `.github/AGENTS.md` as canonical global governance and `.github/agents/workflow.agent.md` for branch lifecycle, promotion, merge, cleanup, and shipping operations.
+- Prefer `rg` / `rg --files` for repository discovery, including `rg --hidden` for governance and hidden config.
+- Do not revert or delete unrelated user changes. Treat untracked hidden project config as potentially important until inspected.
+- Publication and topology changes require branch freshness, collision checks, and open PR awareness.
+- Validation must match the changed surface: Python changes need Python checks; frontend dependency/UI changes need frontend install/test/build/audit as relevant; docs-only work should not claim full product validation unless run.
+- Remote CI failures must be inspected from logs before changing code; distinguish code fixes from token/permission or external workflow failures.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "immich-doctor"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- python
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary
- restore shared Serena project configuration under .serena/project.yml
- add shared Serena project memories that are safe to keep in Git
- add root .gitignore rules for Serena local/runtime files

## Validation
- git check-ignore -v for representative Serena local/runtime paths
- verified .serena/project.yml and shared memories remain trackable
- git diff --check
- serena memories check .
- serena project health-check .

No product code changed; no Python/frontend test suite run.